### PR TITLE
Implements a queue to keep track of in-progress stories

### DIFF
--- a/x/trustory/db/queue.go
+++ b/x/trustory/db/queue.go
@@ -1,0 +1,85 @@
+// Implements a queue on top of the Cosmos key-value store.
+// Useful for managing lists of data, like stories in-progress.
+
+package db
+
+import (
+	ts "github.com/TruStory/trucoin/x/trustory/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var keyActiveStoryQueue = []byte("activeStoriesQueue")
+
+// ActiveStoryQueueHead returns the head of the FIFO queue
+func (k TruKeeper) ActiveStoryQueueHead(ctx sdk.Context) (ts.Story, sdk.Error) {
+	storyQueue, err := k.getActiveStoryQueue(ctx)
+	if err != nil {
+		return ts.Story{}, err
+	}
+	if storyQueue.IsEmpty() {
+		return ts.Story{}, ts.ErrActiveStoryQueueEmpty()
+	}
+	story, err := k.GetStory(ctx, storyQueue[0])
+	if err != nil {
+		return ts.Story{}, err
+	}
+	return story, nil
+}
+
+// ActiveStoryQueuePop pops the head from the story queue
+func (k TruKeeper) ActiveStoryQueuePop(ctx sdk.Context) (ts.Story, sdk.Error) {
+	storyQueue, err := k.getActiveStoryQueue(ctx)
+	if err != nil {
+		return ts.Story{}, err
+	}
+	if storyQueue.IsEmpty() {
+		return ts.Story{}, ts.ErrActiveStoryQueueEmpty()
+	}
+	headElement, tailStoryQueue := storyQueue[0], storyQueue[1:]
+	k.setActiveStoryQueue(ctx, tailStoryQueue)
+	story, err := k.GetStory(ctx, headElement)
+	if err != nil {
+		return ts.Story{}, err
+	}
+	return story, nil
+}
+
+// ActiveStoryQueuePush pushes a story to the tail of the FIFO queue
+func (k TruKeeper) ActiveStoryQueuePush(ctx sdk.Context, storyID int64) sdk.Error {
+	storyQueue, err := k.getActiveStoryQueue(ctx)
+	if err != nil {
+		return err
+	}
+	storyQueue = append(storyQueue, storyID)
+	k.setActiveStoryQueue(ctx, storyQueue)
+	return nil
+}
+
+// ============================================================================
+
+// getActiveStoryQueue gets the StoryQueue from the context
+func (k TruKeeper) getActiveStoryQueue(ctx sdk.Context) (ts.ActiveStoryQueue, sdk.Error) {
+	store := ctx.KVStore(k.StoryKey)
+	bsq := store.Get(keyActiveStoryQueue)
+	if bsq == nil {
+		return ts.ActiveStoryQueue{}, ts.ErrActiveStoryQueueNotFound()
+	}
+
+	storyQueue := &ts.ActiveStoryQueue{}
+	err := k.Cdc.UnmarshalBinary(bsq, storyQueue)
+	if err != nil {
+		panic(err)
+	}
+
+	return *storyQueue, nil
+}
+
+// setActiveStoryQueue sets the ActiveStoryQueue to the context
+func (k TruKeeper) setActiveStoryQueue(ctx sdk.Context, storyQueue ts.ActiveStoryQueue) {
+	store := ctx.KVStore(k.StoryKey)
+	bsq, err := k.Cdc.MarshalBinary(storyQueue)
+	if err != nil {
+		panic(err)
+	}
+	store.Set(keyActiveStoryQueue, bsq)
+}

--- a/x/trustory/db/queue_test.go
+++ b/x/trustory/db/queue_test.go
@@ -1,0 +1,47 @@
+package db
+
+import (
+	"testing"
+
+	ts "github.com/TruStory/trucoin/x/trustory/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+func TestActiveStoryQueue(t *testing.T) {
+	ms, storyKey, voteKey := setupMultiStore()
+	cdc := makeCodec()
+	k := NewTruKeeper(storyKey, voteKey, cdc)
+	ctx := sdk.NewContext(ms, abci.Header{}, false, log.NewNopLogger())
+	storyID := createFakeStory(ms, k)
+
+	_, err := k.ActiveStoryQueueHead(ctx)
+	assert.NotNil(t, err)
+	assert.Equal(t, sdk.CodeType(711), err.Code(), err.Error())
+
+	_, err = k.ActiveStoryQueuePop(ctx)
+	assert.NotNil(t, err)
+	assert.Equal(t, sdk.CodeType(711), err.Code(), err.Error())
+
+	// create an empty story queue
+	k.setActiveStoryQueue(ctx, ts.ActiveStoryQueue{})
+
+	_, err = k.ActiveStoryQueueHead(ctx)
+	assert.NotNil(t, err)
+	assert.Equal(t, sdk.CodeType(712), err.Code(), err.Error())
+
+	_, err = k.ActiveStoryQueuePop(ctx)
+	assert.NotNil(t, err)
+	assert.Equal(t, sdk.CodeType(712), err.Code(), err.Error())
+
+	err = k.ActiveStoryQueuePush(ctx, storyID)
+	assert.Nil(t, err)
+
+	story, _ := k.ActiveStoryQueueHead(ctx)
+	assert.NotNil(t, story)
+
+	story, _ = k.ActiveStoryQueuePop(ctx)
+	assert.NotNil(t, story)
+}

--- a/x/trustory/types/errors.go
+++ b/x/trustory/types/errors.go
@@ -10,16 +10,18 @@ import (
 const (
 	DefaultCodespace sdk.CodespaceType = 7
 
-	CodeInvalidOption     sdk.CodeType = 701
-	CodeInvalidBody       sdk.CodeType = 702
-	CodeInvalidStoryID    sdk.CodeType = 703
-	CodeStoryNotFound     sdk.CodeType = 704
-	CodeInvalidAmount     sdk.CodeType = 705
-	CodeInvalidBondPeriod sdk.CodeType = 706
-	CodeInvalidURL        sdk.CodeType = 707
-	CodeInvalidCategory   sdk.CodeType = 708
-	CodeInvalidStoryType  sdk.CodeType = 709
-	CodeVoteNotFoundType  sdk.CodeType = 710
+	CodeInvalidOption            sdk.CodeType = 701
+	CodeInvalidBody              sdk.CodeType = 702
+	CodeInvalidStoryID           sdk.CodeType = 703
+	CodeStoryNotFound            sdk.CodeType = 704
+	CodeInvalidAmount            sdk.CodeType = 705
+	CodeInvalidBondPeriod        sdk.CodeType = 706
+	CodeInvalidURL               sdk.CodeType = 707
+	CodeInvalidCategory          sdk.CodeType = 708
+	CodeInvalidStoryType         sdk.CodeType = 709
+	CodeVoteNotFoundType         sdk.CodeType = 710
+	CodeActiveStoryQueueNotFound sdk.CodeType = 711
+	CodeActiveStoryQueueEmpty    sdk.CodeType = 712
 )
 
 func codeToDefaultMsg(code sdk.CodeType) string {
@@ -82,6 +84,16 @@ func ErrStoryNotFound(storyID int64) sdk.Error {
 func ErrVoteNotFound(voteID int64) sdk.Error {
 	return newError(DefaultCodespace, CodeVoteNotFoundType, "Vote with id "+
 		strconv.Itoa(int(voteID))+" not found")
+}
+
+// ErrActiveStoryQueueNotFound throws an error when the searched ActiveStoryQueue is not found
+func ErrActiveStoryQueueNotFound() sdk.Error {
+	return newError(DefaultCodespace, CodeActiveStoryQueueNotFound, "Active story queue not found")
+}
+
+// ErrActiveStoryQueueEmpty throws an error when the searched ActiveStoryQueue is not found
+func ErrActiveStoryQueueEmpty() sdk.Error {
+	return newError(DefaultCodespace, CodeActiveStoryQueueEmpty, "Active story queue is empty")
 }
 
 //----------------------------------------

--- a/x/trustory/types/types.go
+++ b/x/trustory/types/types.go
@@ -251,3 +251,16 @@ func NewVote(
 		Vote:         vote,
 	}
 }
+
+// ============================================================================
+
+// ActiveStoryQueue is a queue of in-progress stories -- `Created` and `Challenged`
+type ActiveStoryQueue []int64
+
+// IsEmpty checks if the queue is empty
+func (asq ActiveStoryQueue) IsEmpty() bool {
+	if len(asq) == 0 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This implements a FIFO queue on top of the Cosmos key-value store to keep track of in-progress stories (stories currently being voted on). This way, we don't have to iterate through every story to find which ones are in progress. The voting checking logic will run after every block, so we need to be as lean as possible.

The voting PR is getting too big so I thought I'll break it up into parts. This is the first part.