### PR TITLE
Abstracted out keeper into read and write interfaces

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -44,8 +44,8 @@ type TruChain struct {
 	coinKeeper          bank.Keeper
 	ibcMapper           ibc.Mapper
 
-	// access story and vote database
-	keeper sdb.TruKeeper
+	// access truchain database
+	keeper sdb.WriteKeeper
 }
 
 // NewTruChain returns a reference to a new TruChain. Internally,

--- a/x/truchain/db/keeper.go
+++ b/x/truchain/db/keeper.go
@@ -2,11 +2,51 @@ package db
 
 import (
 	"fmt"
+	"time"
 
+	ts "github.com/TruStory/truchain/x/truchain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	amino "github.com/tendermint/go-amino"
+	abci "github.com/tendermint/tendermint/abci/types"
 )
+
+// ReadKeeper defines a module interface that facilitates read only access
+// to truchain data
+type ReadKeeper interface {
+	BackingQueueHead(ctx sdk.Context) (ts.Backing, sdk.Error)
+	BackQueueLen(ctx sdk.Context) int
+	GetBacking(ctx sdk.Context, id int64) (ts.Backing, sdk.Error)
+	GetStory(ctx sdk.Context, storyID int64) (ts.Story, sdk.Error)
+}
+
+// WriteKeeper defines a module interface that facilities write only access
+// to truchain data
+type WriteKeeper interface {
+	BackingQueuePop(ctx sdk.Context) (ts.Backing, sdk.Error)
+	BackingQueuePush(ctx sdk.Context, id int64)
+	NewBacking(
+		ctx sdk.Context,
+		storyID int64,
+		amount sdk.Coin,
+		creator sdk.AccAddress,
+		duration time.Duration,
+	) (int64, sdk.Error)
+	NewResponseEndBlock(ctx sdk.Context) abci.ResponseEndBlock
+	NewStory(
+		ctx sdk.Context,
+		body string,
+		category ts.StoryCategory,
+		creator sdk.AccAddress,
+		storyType ts.StoryType) (int64, sdk.Error)
+}
+
+// Keeper defines a module interface that facilities read/write access
+// to truchain data
+type Keeper interface {
+	ReadKeeper
+	WriteKeeper
+}
 
 // TruKeeper data type storing keys to the key-value store
 type TruKeeper struct {

--- a/x/truchain/handler.go
+++ b/x/truchain/handler.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewHandler creates a new handler for all TruStory messages
-func NewHandler(k db.TruKeeper) sdk.Handler {
+func NewHandler(k db.WriteKeeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		switch msg := msg.(type) {
 		case ts.SubmitStoryMsg:
@@ -27,7 +27,7 @@ func NewHandler(k db.TruKeeper) sdk.Handler {
 // ============================================================================
 
 // handleSubmitStoryMsg handles the logic of a SubmitStoryMsg
-func handleSubmitStoryMsg(ctx sdk.Context, k db.TruKeeper, msg ts.SubmitStoryMsg) sdk.Result {
+func handleSubmitStoryMsg(ctx sdk.Context, k db.WriteKeeper, msg ts.SubmitStoryMsg) sdk.Result {
 	if err := msg.ValidateBasic(); err != nil {
 		return err.Result()
 	}
@@ -40,7 +40,7 @@ func handleSubmitStoryMsg(ctx sdk.Context, k db.TruKeeper, msg ts.SubmitStoryMsg
 	return sdk.Result{Data: i2b(storyID)}
 }
 
-func handleBackStoryMsg(ctx sdk.Context, k db.TruKeeper, msg ts.BackStoryMsg) sdk.Result {
+func handleBackStoryMsg(ctx sdk.Context, k db.WriteKeeper, msg ts.BackStoryMsg) sdk.Result {
 	if err := msg.ValidateBasic(); err != nil {
 		return err.Result()
 	}


### PR DESCRIPTION
Should be a useful abstraction for clients. Modules can now get a read-only keeper or write keeper depending on if they are mutating state.

Fixes #31.
