### PR TITLE
Set minimum fee amount for spam prevention

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -180,6 +180,9 @@ func NewTruChain(logger log.Logger, db dbm.DB, options ...func(*bam.BaseApp)) *T
 	app.SetEndBlocker(app.EndBlocker)
 	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper))
 
+	// set fee for spam prevention and validator rewards
+	app.SetMinimumFees(params.Fee)
+
 	// mount the multistore and load the latest state
 	app.MountStoresIAVL(
 		app.keyMain, app.keyAccount, app.keyIBC, app.keyFee, app.keyGameQueue,

--- a/parameters/parameters.go
+++ b/parameters/parameters.go
@@ -33,3 +33,8 @@ var RegistrationFee = auth.StdFee{
 	Amount: sdk.Coins{sdk.Coin{Amount: sdk.NewInt(1), Denom: StakeDenom}},
 	Gas:    10000,
 }
+
+// Fee is for spam prevention and validator rewards
+var Fee = sdk.Coins{
+	sdk.Coin{Amount: sdk.NewInt(10), Denom: StakeDenom},
+}


### PR DESCRIPTION
Fixes #38.

This should set a minimum fee for all transactions. Can't currently test this with unit tests, so we'll have to test it with the app and fake accounts with funds.

I suggest testing the create flow before this is merged in to make sure everything works without fees first.
