### PR TITLE
Wrapped setting minimum fee in a feature flag and turned it off

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -181,7 +181,9 @@ func NewTruChain(logger log.Logger, db dbm.DB, options ...func(*bam.BaseApp)) *T
 	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper))
 
 	// set fee for spam prevention and validator rewards
-	app.SetMinimumFees(params.Fee)
+	if params.Features[params.FeeFlag] {
+		app.SetMinimumFees(params.Fee)
+	}
 
 	// mount the multistore and load the latest state
 	app.MountStoresIAVL(

--- a/parameters/parameters.go
+++ b/parameters/parameters.go
@@ -38,3 +38,13 @@ var RegistrationFee = auth.StdFee{
 var Fee = sdk.Coins{
 	sdk.Coin{Amount: sdk.NewInt(10), Denom: StakeDenom},
 }
+
+// Feature flags
+const (
+	FeeFlag = iota
+)
+
+// Features sets flags on features to turn on/off during testnet
+var Features = map[int]bool{
+	FeeFlag: false,
+}


### PR DESCRIPTION
Fixes #175.

To add fees back, simply change `false` in params to `true` in `parameters.go`:

```go
// Features sets flags on features to turn on/off during testnet
var Features = map[int]bool{
	FeeFlag: false,
}
```

Fees broke registration. Lets turn it off for now and finish the API. I. believe Cosmos is still actively working on fees so probably best to hold off on it anyway.