### PR TITLE
Fix message routes/types

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -166,7 +166,7 @@ func NewTruChain(logger log.Logger, db dbm.DB, options ...func(*bam.BaseApp)) *T
 		AddRoute("backing", backing.NewHandler(app.backingKeeper)).
 		AddRoute("challenge", challenge.NewHandler(app.challengeKeeper)).
 		AddRoute("vote", vote.NewHandler(app.voteKeeper)).
-		AddRoute(users.RegisterKeyMsg{}.Route(), users.NewHandler(app.accountKeeper))
+		AddRoute("users", users.NewHandler(app.accountKeeper))
 
 	// register query routes for reading state
 	app.QueryRouter().

--- a/types/msg.go
+++ b/types/msg.go
@@ -12,14 +12,14 @@ import (
 
 // Utilities for all `sdk.Msg` types
 
-// GetType returns the package name of the containing `Msg`
-func GetType(msg sdk.Msg) string {
+// GetRoute returns the package name of the containing `Msg`
+func GetRoute(msg sdk.Msg) string {
 	pkgPath := reflect.TypeOf(msg).PkgPath()
 	return path.Base(pkgPath)
 }
 
-// GetName returns the name of the `Msg` in snake_case
-func GetName(msg sdk.Msg) string {
+// GetType returns the name of the `Msg` in snake_case
+func GetType(msg sdk.Msg) string {
 	name := reflect.TypeOf(msg).Name()
 	prefix := strings.Split(toSnakeCase(name), "_")
 	return strings.Join(prefix[:len(prefix)-1], "_")

--- a/x/backing/msg.go
+++ b/x/backing/msg.go
@@ -31,11 +31,11 @@ func NewBackStoryMsg(
 	}
 }
 
+// Route implements Msg
+func (msg BackStoryMsg) Route() string { return app.GetRoute(msg) }
+
 // Type implements Msg
 func (msg BackStoryMsg) Type() string { return app.GetType(msg) }
-
-// Route implements Msg
-func (msg BackStoryMsg) Route() string { return app.GetName(msg) }
 
 // GetSignBytes implements Msg
 func (msg BackStoryMsg) GetSignBytes() []byte {

--- a/x/backing/msg_test.go
+++ b/x/backing/msg_test.go
@@ -18,8 +18,8 @@ func TestValidBackMsg(t *testing.T) {
 	err := msg.ValidateBasic()
 
 	assert.Nil(t, err)
-	assert.Equal(t, "backing", msg.Type())
-	assert.Equal(t, "back_story", msg.Route())
+	assert.Equal(t, "backing", msg.Route())
+	assert.Equal(t, "back_story", msg.Type())
 	assert.Equal(
 		t,
 		`{"amount":{"amount":"100","denom":"trustake"},"creator":"cosmos1qypq36vzru","duration":259200000000000,"story_id":1}`,

--- a/x/category/msg.go
+++ b/x/category/msg.go
@@ -29,7 +29,7 @@ func NewCreateCategoryMsg(
 }
 
 // Route implements Msg
-func (msg CreateCategoryMsg) Route() string { return app.GetName(msg) }
+func (msg CreateCategoryMsg) Route() string { return app.GetRoute(msg) }
 
 // Type implements Msg
 func (msg CreateCategoryMsg) Type() string { return app.GetType(msg) }

--- a/x/category/msg_test.go
+++ b/x/category/msg_test.go
@@ -16,8 +16,8 @@ func TestCreateCategoryMsg(t *testing.T) {
 	msg := NewCreateCategoryMsg(validTitle, validCreator, validSlug, validDescription)
 	err := msg.ValidateBasic()
 	assert.Nil(t, err)
-	assert.Equal(t, "category", msg.Type())
-	assert.Equal(t, "create_category", msg.Route())
+	assert.Equal(t, "category", msg.Route())
+	assert.Equal(t, "create_category", msg.Type())
 }
 
 func TestCreateCategoryMsg_Invalid(t *testing.T) {

--- a/x/challenge/msg.go
+++ b/x/challenge/msg.go
@@ -34,11 +34,11 @@ func NewCreateChallengeMsg(
 	}
 }
 
+// Route implements Msg
+func (msg CreateChallengeMsg) Route() string { return app.GetRoute(msg) }
+
 // Type implements Msg
 func (msg CreateChallengeMsg) Type() string { return app.GetType(msg) }
-
-// Route implements Msg
-func (msg CreateChallengeMsg) Route() string { return app.GetName(msg) }
 
 // GetSignBytes implements Msg. Story creator should sign this message.
 // Serializes Msg into JSON bytes for transport.

--- a/x/challenge/msg_test.go
+++ b/x/challenge/msg_test.go
@@ -21,8 +21,8 @@ func TestValidStartChallengeMsg(t *testing.T) {
 	err := msg.ValidateBasic()
 	assert.Nil(t, err)
 
-	assert.Equal(t, "challenge", msg.Type())
-	assert.Equal(t, "create_challenge", msg.Route())
+	assert.Equal(t, "challenge", msg.Route())
+	assert.Equal(t, "create_challenge", msg.Type())
 	assert.Equal(t, []sdk.AccAddress{validCreator}, msg.GetSigners())
 }
 

--- a/x/story/msg.go
+++ b/x/story/msg.go
@@ -41,10 +41,10 @@ func NewSubmitStoryMsg(
 }
 
 // Route implements Msg
-func (msg SubmitStoryMsg) Route() string { return app.GetType(msg) }
+func (msg SubmitStoryMsg) Route() string { return app.GetRoute(msg) }
 
 // Type implements Msg
-func (msg SubmitStoryMsg) Type() string { return app.GetName(msg) }
+func (msg SubmitStoryMsg) Type() string { return app.GetType(msg) }
 
 // GetSignBytes implements Msg. Story creator should sign this message.
 // Serializes Msg into JSON bytes for transport.
@@ -101,7 +101,7 @@ func NewAddArgumentMsg(storyID int64, creator sdk.AccAddress, argument string) A
 }
 
 // Route implements Msg.Route
-func (msg AddArgumentMsg) Route() string { return app.GetName(msg) }
+func (msg AddArgumentMsg) Route() string { return app.GetRoute(msg) }
 
 // Type implements Msg.Type
 func (msg AddArgumentMsg) Type() string { return app.GetType(msg) }
@@ -149,7 +149,7 @@ func NewAddEvidenceMsg(storyID int64, creator sdk.AccAddress, url string) AddEvi
 }
 
 // Route implements Msg
-func (msg AddEvidenceMsg) Route() string { return app.GetName(msg) }
+func (msg AddEvidenceMsg) Route() string { return app.GetRoute(msg) }
 
 // Type implements Msg
 func (msg AddEvidenceMsg) Type() string { return app.GetType(msg) }
@@ -196,7 +196,7 @@ func NewFlagStoryMsg(storyID int64, creator sdk.AccAddress) FlagStoryMsg {
 }
 
 // Route implements Msg.Route
-func (msg FlagStoryMsg) Route() string { return app.GetName(msg) }
+func (msg FlagStoryMsg) Route() string { return app.GetRoute(msg) }
 
 // Type implements Msg.Type
 func (msg FlagStoryMsg) Type() string { return app.GetType(msg) }

--- a/x/story/msg_test.go
+++ b/x/story/msg_test.go
@@ -80,8 +80,8 @@ func TestValidAddEvidencetMsg(t *testing.T) {
 	err := msg.ValidateBasic()
 
 	assert.Nil(t, err)
-	assert.Equal(t, "story", msg.Type())
-	assert.Equal(t, "add_evidence", msg.Route())
+	assert.Equal(t, "story", msg.Route())
+	assert.Equal(t, "add_evidence", msg.Type())
 	assert.Equal(
 		t,
 		`{"creator":"cosmos1qypq36vzru","story_id":1,"url":"http://www.truchain.io"}`,
@@ -98,8 +98,8 @@ func TestValidAddArgumentMsg(t *testing.T) {
 	err := msg.ValidateBasic()
 
 	assert.Nil(t, err)
-	assert.Equal(t, "story", msg.Type())
-	assert.Equal(t, "add_argument", msg.Route())
+	assert.Equal(t, "story", msg.Route())
+	assert.Equal(t, "add_argument", msg.Type())
 	assert.Equal(
 		t,
 		`{"argument":"another argument","creator":"cosmos1qypq36vzru","story_id":1}`,
@@ -115,8 +115,8 @@ func TestValidFlagStoryMsg(t *testing.T) {
 	err := msg.ValidateBasic()
 
 	assert.Nil(t, err)
-	assert.Equal(t, "story", msg.Type())
-	assert.Equal(t, "flag_story", msg.Route())
+	assert.Equal(t, "story", msg.Route())
+	assert.Equal(t, "flag_story", msg.Type())
 	assert.Equal(
 		t,
 		`{"creator":"cosmos1qypq36vzru","story_id":1}`,

--- a/x/users/msg.go
+++ b/x/users/msg.go
@@ -14,11 +14,11 @@ type RegisterKeyMsg struct {
 	Coins      sdk.Coins      `json:"coins"`
 }
 
+// Route implements Msg
+func (msg RegisterKeyMsg) Route() string { return app.GetRoute(msg) }
+
 // Type implements Msg
 func (msg RegisterKeyMsg) Type() string { return app.GetType(msg) }
-
-// Route implements Msg
-func (msg RegisterKeyMsg) Route() string { return app.GetType(msg) }
 
 // GetSignBytes implements Msg
 func (msg RegisterKeyMsg) GetSignBytes() []byte {

--- a/x/vote/msg.go
+++ b/x/vote/msg.go
@@ -37,11 +37,11 @@ func NewCreateVoteMsg(
 	}
 }
 
+// Route implements Msg
+func (msg CreateVoteMsg) Route() string { return app.GetRoute(msg) }
+
 // Type implements Msg
 func (msg CreateVoteMsg) Type() string { return app.GetType(msg) }
-
-// Route implements Msg
-func (msg CreateVoteMsg) Route() string { return app.GetName(msg) }
 
 // GetSignBytes implements Msg. Story creator should sign this message.
 // Serializes Msg into JSON bytes for transport.

--- a/x/vote/msg_test.go
+++ b/x/vote/msg_test.go
@@ -22,8 +22,8 @@ func TestValidCreateVoteMsg(t *testing.T) {
 	err := msg.ValidateBasic()
 	assert.Nil(t, err)
 
-	assert.Equal(t, "vote", msg.Type())
-	assert.Equal(t, "create_vote", msg.Route())
+	assert.Equal(t, "vote", msg.Route())
+	assert.Equal(t, "create_vote", msg.Type())
 	assert.Equal(t, []sdk.AccAddress{creator}, msg.GetSigners())
 }
 


### PR DESCRIPTION
Some context: while trying to integrate story backing in mobile, I came across some inconsistencies of how message Route() and message Type() were defined. My understanding is that we want routes to correspond to package names while types correspond to a specific action for that type. Examples:

```
route: story, type: submit_story
route: story, type: add_argument
route: story, type: flag_story
route: backing, type: add_backing
etc.
```

I fixed up all the inconsistencies but maybe I got the role of route/type reversed.