### PR TITLE
Make CreateChallengeMsg compatible with blockchain client

### DIFF
--- a/x/challenge/errors.go
+++ b/x/challenge/errors.go
@@ -15,6 +15,7 @@ const (
 	CodeInvalidMsg         sdk.CodeType = 1002
 	CodeInvalidVote        sdk.CodeType = 1003
 	CodeDuplicateChallenge sdk.CodeType = 1004
+	CodeInvalidEvidenceURL sdk.CodeType = 1005
 )
 
 // ErrNotFound creates an error when the searched entity is not found
@@ -47,4 +48,12 @@ func ErrInvalidVote() sdk.Error {
 		DefaultCodespace,
 		CodeInvalidMsg,
 		"Challenges cannot have a TRUE vote.")
+}
+
+// ErrInvalidEvidenceURL throws an error when a URL in invalid
+func ErrInvalidEvidenceURL(url string) sdk.Error {
+	return sdk.NewError(
+		DefaultCodespace,
+		CodeInvalidEvidenceURL,
+		"Invalid evidence URL: "+url)
 }

--- a/x/challenge/handler.go
+++ b/x/challenge/handler.go
@@ -1,6 +1,8 @@
 package challenge
 
 import (
+	"net/url"
+
 	app "github.com/TruStory/truchain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -27,8 +29,19 @@ func handleCreateChallengeMsg(
 		return err.Result()
 	}
 
+	var evidence []url.URL
+	for _, urlString := range msg.Evidence {
+
+		evidenceURL, urlError := url.ParseRequestURI(urlString)
+		if urlError != nil {
+			return ErrInvalidEvidenceURL(urlString).Result()
+		}
+
+		evidence = append(evidence, *evidenceURL)
+	}
+
 	id, err := k.Create(
-		ctx, msg.StoryID, msg.Amount, msg.Argument, msg.Creator, msg.Evidence)
+		ctx, msg.StoryID, msg.Amount, msg.Argument, msg.Creator, evidence)
 	if err != nil {
 		return err.Result()
 	}

--- a/x/challenge/handler_test.go
+++ b/x/challenge/handler_test.go
@@ -3,7 +3,6 @@ package challenge
 import (
 	"encoding/binary"
 	"encoding/json"
-	"net/url"
 	"testing"
 
 	"github.com/TruStory/truchain/types"
@@ -21,8 +20,7 @@ func TestSubmitChallengeMsg(t *testing.T) {
 	amount := sdk.NewCoin("trudex", sdk.NewInt(15))
 	argument := "test argument"
 	creator := sdk.AccAddress([]byte{1, 2})
-	cnn, _ := url.Parse("http://www.cnn.com")
-	evidence := []url.URL{*cnn}
+	evidence := []string{"http://www.cnn.com"}
 
 	// give user some funds
 	bankKeeper.AddCoins(ctx, creator, sdk.Coins{amount})
@@ -47,8 +45,7 @@ func TestSubmitChallengeMsg_ErrInsufficientFunds(t *testing.T) {
 	amount := sdk.NewCoin("testcoin", sdk.NewInt(5))
 	argument := "test argument"
 	creator := sdk.AccAddress([]byte{1, 2})
-	cnn, _ := url.Parse("http://www.cnn.com")
-	evidence := []url.URL{*cnn}
+	evidence := []string{"http://www.cnn.com"}
 
 	msg := NewCreateChallengeMsg(storyID, amount, argument, creator, evidence)
 	assert.NotNil(t, msg)
@@ -68,8 +65,7 @@ func TestSubmitChallengeMsg_ErrInsufficientChallengeAmount(t *testing.T) {
 	amount := sdk.NewCoin("trudex", sdk.NewInt(1))
 	argument := "test argument"
 	creator := sdk.AccAddress([]byte{1, 2})
-	cnn, _ := url.Parse("http://www.cnn.com")
-	evidence := []url.URL{*cnn}
+	evidence := []string{"http://www.cnn.com"}
 
 	// give user some funds
 	bankKeeper.AddCoins(ctx, creator, sdk.Coins{amount})

--- a/x/challenge/msg.go
+++ b/x/challenge/msg.go
@@ -1,8 +1,6 @@
 package challenge
 
 import (
-	"net/url"
-
 	"github.com/TruStory/truchain/x/story"
 
 	app "github.com/TruStory/truchain/types"
@@ -15,7 +13,7 @@ type CreateChallengeMsg struct {
 	Amount   sdk.Coin       `json:"amount"`
 	Argument string         `json:"argument,omitempty"`
 	Creator  sdk.AccAddress `json:"creator"`
-	Evidence []url.URL      `json:"evidence,omitempty"`
+	Evidence []string       `json:"evidence,omitempty"`
 }
 
 // NewCreateChallengeMsg creates a message to challenge a story
@@ -24,7 +22,7 @@ func NewCreateChallengeMsg(
 	amount sdk.Coin,
 	argument string,
 	creator sdk.AccAddress,
-	evidence []url.URL) CreateChallengeMsg {
+	evidence []string) CreateChallengeMsg {
 	return CreateChallengeMsg{
 		StoryID:  storyID,
 		Amount:   amount,

--- a/x/challenge/msg_test.go
+++ b/x/challenge/msg_test.go
@@ -1,7 +1,6 @@
 package challenge
 
 import (
-	"net/url"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -14,8 +13,7 @@ func TestValidStartChallengeMsg(t *testing.T) {
 	validAmount := sdk.NewCoin("testcoin", sdk.NewInt(5))
 	validArugment := "I am against this story because, you know, just cuz."
 	validCreator := sdk.AccAddress([]byte{1, 2})
-	cnn, _ := url.Parse("http://www.cnn.com")
-	validEvidence := []url.URL{*cnn}
+	validEvidence := []string{"http://www.cnn.com"}
 
 	msg := NewCreateChallengeMsg(validStoryID, validAmount, validArugment, validCreator, validEvidence)
 	err := msg.ValidateBasic()
@@ -32,8 +30,8 @@ func TestInValidStartChallengeMsg(t *testing.T) {
 	validAmount := sdk.NewCoin("testcoin", sdk.NewInt(5))
 	validArugment := "I am against this story because, you know, just cuz."
 	validCreator := sdk.AccAddress([]byte{1, 2})
-	cnn, _ := url.Parse("http://www.cnn.com")
-	validEvidence := []url.URL{*cnn, *cnn, *cnn, *cnn, *cnn, *cnn, *cnn, *cnn, *cnn, *cnn, *cnn}
+	cnn := "http://www.cnn.com"
+	validEvidence := []string{cnn, cnn, cnn, cnn, cnn, cnn, cnn, cnn, cnn, cnn, cnn}
 
 	msg := NewCreateChallengeMsg(validStoryID, validAmount, validArugment, validCreator, validEvidence)
 	err := msg.ValidateBasic()


### PR DESCRIPTION
Need this change because the client cannot send a signed request with URL.url type.