### PR TITLE
Remove evidence from SubmitStoryMsg

### DIFF
--- a/x/story/handler.go
+++ b/x/story/handler.go
@@ -40,20 +40,6 @@ func handleSubmitStoryMsg(ctx sdk.Context, k WriteKeeper, msg SubmitStoryMsg) sd
 
 	// create evidence type from url
 	var evidence []Evidence
-	for _, urlString := range msg.Evidence {
-
-		evidenceURL, urlError := url.ParseRequestURI(urlString)
-		if urlError != nil {
-			return ErrInvalidEvidenceURL(urlString).Result()
-		}
-
-		e := Evidence{
-			Creator:   msg.Creator,
-			URL:       *evidenceURL,
-			Timestamp: app.NewTimestamp(ctx.BlockHeader()),
-		}
-		evidence = append(evidence, e)
-	}
 
 	argument := Argument{}
 	if len(msg.Argument) > 0 {

--- a/x/story/handler_test.go
+++ b/x/story/handler_test.go
@@ -23,10 +23,9 @@ func TestSubmitStoryMsg(t *testing.T) {
 	creator := sdk.AccAddress([]byte{1, 2})
 	kind := Default
 	source := "http://trustory.io"
-	evidence := []string{"http://shanesbrain.net"}
 	argument := "argument body"
 
-	msg := NewSubmitStoryMsg(argument, body, cat.ID, creator, evidence, source, kind)
+	msg := NewSubmitStoryMsg(argument, body, cat.ID, creator, source, kind)
 	assert.NotNil(t, msg)
 
 	res := h(ctx, msg)
@@ -52,10 +51,9 @@ func TestSubmitStoryMsgWithOnlyRequiredFields(t *testing.T) {
 	creator := sdk.AccAddress([]byte{1, 2})
 	kind := Default
 	source := "http://trustory.io"
-	evidence := []string{}
 	argument := ""
 
-	msg := NewSubmitStoryMsg(argument, body, cat.ID, creator, evidence, source, kind)
+	msg := NewSubmitStoryMsg(argument, body, cat.ID, creator, source, kind)
 	assert.NotNil(t, msg)
 
 	res := h(ctx, msg)
@@ -81,9 +79,8 @@ func TestSubmitStoryMsg_ErrInvalidCategory(t *testing.T) {
 	creator := sdk.AccAddress([]byte{1, 2})
 	kind := Default
 	source := "http://trustory.io"
-	evidence := []string{"http://shanesbrain.net"}
 	argument := "argument body"
-	msg := NewSubmitStoryMsg(argument, body, catID, creator, evidence, source, kind)
+	msg := NewSubmitStoryMsg(argument, body, catID, creator, source, kind)
 	assert.NotNil(t, msg)
 
 	res := h(ctx, msg)

--- a/x/story/msg.go
+++ b/x/story/msg.go
@@ -15,7 +15,6 @@ type SubmitStoryMsg struct {
 	CategoryID int64          `json:"category_id"`
 	Creator    sdk.AccAddress `json:"creator"`
 	Source     string         `json:"source"`
-	Evidence   []string       `json:"evidence,omitempty"`
 	StoryType  Type           `json:"story_type"`
 }
 
@@ -25,7 +24,6 @@ func NewSubmitStoryMsg(
 	body string,
 	categoryID int64,
 	creator sdk.AccAddress,
-	evidence []string,
 	source string,
 	storyType Type) SubmitStoryMsg {
 
@@ -34,7 +32,6 @@ func NewSubmitStoryMsg(
 		Body:       body,
 		CategoryID: categoryID,
 		Creator:    creator,
-		Evidence:   evidence,
 		Source:     source,
 		StoryType:  storyType,
 	}

--- a/x/story/msg_test.go
+++ b/x/story/msg_test.go
@@ -14,9 +14,8 @@ func TestValidSubmitStoryMsg(t *testing.T) {
 	validCreator := sdk.AccAddress([]byte{1, 2})
 	validSource := "http://shanesbrain.net"
 	validStoryType := Default
-	validEvidence := []string{"http://shanesbrain.net"}
 	validArgument := "argument body"
-	msg := NewSubmitStoryMsg(validArgument, validBody, validCategoryID, validCreator, validEvidence, validSource, validStoryType)
+	msg := NewSubmitStoryMsg(validArgument, validBody, validCategoryID, validCreator, validSource, validStoryType)
 	err := msg.ValidateBasic()
 
 	assert.Nil(t, err)
@@ -31,10 +30,9 @@ func TestInValidBodySubmitStoryMsg(t *testing.T) {
 	validCreator := sdk.AccAddress([]byte{1, 2})
 	validSource := "http://shanesbrain.net"
 	validStoryType := Default
-	validEvidence := []string{"http://shanesbrain.net"}
 	validArgument := "argument"
 
-	msg := NewSubmitStoryMsg(validArgument, invalidBody, validCategoryID, validCreator, validEvidence, validSource, validStoryType)
+	msg := NewSubmitStoryMsg(validArgument, invalidBody, validCategoryID, validCreator, validSource, validStoryType)
 	err := msg.ValidateBasic()
 
 	assert.Equal(t, sdk.CodeType(701), err.Code(), err.Error())
@@ -46,10 +44,9 @@ func TestInValidCreatorSubmitStoryMsg(t *testing.T) {
 	invalidCreator := sdk.AccAddress([]byte{})
 	validSource := "http://shanesbrain.net"
 	validStoryType := Default
-	validEvidence := []string{"http://shanesbrain.net"}
 	validArgument := "argument"
 
-	msg := NewSubmitStoryMsg(validArgument, validBody, validCategoryID, invalidCreator, validEvidence, validSource, validStoryType)
+	msg := NewSubmitStoryMsg(validArgument, validBody, validCategoryID, invalidCreator, validSource, validStoryType)
 	err := msg.ValidateBasic()
 
 	assert.Equal(t, sdk.CodeType(7), err.Code(), err.Error())
@@ -61,10 +58,9 @@ func TestInValidSourceSubmitStoryMsg(t *testing.T) {
 	validCreator := sdk.AccAddress([]byte{1, 2})
 	invalidSource := ""
 	validStoryType := Default
-	validEvidence := []string{"http://shanesbrain.net"}
 	validArgument := ""
 
-	msg := NewSubmitStoryMsg(validArgument, validBody, validCategoryID, validCreator, validEvidence, invalidSource, validStoryType)
+	msg := NewSubmitStoryMsg(validArgument, validBody, validCategoryID, validCreator, invalidSource, validStoryType)
 	err := msg.ValidateBasic()
 
 	assert.Equal(t, sdk.CodeType(708), err.Code(), err.Error())


### PR DESCRIPTION
Signature verification currently fails if the client submits a message that contains an empty array. For example on submitstorymsg we have the following fields:

```
type SubmitStoryMsg struct {
	Argument   string         `json:"argument,omitempty"`
	Body       string         `json:"body"`
	CategoryID int64          `json:"category_id"`
	Creator    sdk.AccAddress `json:"creator"`
	Source     string         `json:"source"`
	Evidence   []string       `json:"evidence,omitempty"`
	StoryType  Type           `json:"story_type"`
}
```

I have a PR that removes Evidence from the UI on story creation (since we will parse it from arguments) and submitting a default `['http://trustory.io']` value for evidence on every story because I can't figure out how to get the signing to work with an empty array. I don't want to sink a lot of time into the signature generation at this point so instead of submitting a default value, we can also remove Evidence from the SubmitStoryMsg. Thoughts?