### PR TITLE
Prevent challenge threshold from going below min challenge stake

### DIFF
--- a/x/game/keeper.go
+++ b/x/game/keeper.go
@@ -184,16 +184,15 @@ func (k Keeper) RegisterVote(ctx sdk.Context, gameID int64) (err sdk.Error) {
 func (k Keeper) ChallengeThreshold(totalBackingAmount sdk.Coin) sdk.Coin {
 	params := DefaultParams()
 
-	// we have zero backers
-	// challenge threshold equals min challenge stake
-	if totalBackingAmount.IsZero() {
-		return sdk.NewCoin(totalBackingAmount.Denom, params.MinChallengeStake)
-	}
-
 	// we have backers
 	// calculate challenge threshold amount (based on total backings)
 	totalBackingDec := sdk.NewDecFromInt(totalBackingAmount.Amount)
 	challengeThresholdAmount := totalBackingDec.Mul(params.ChallengeToBackingRatio).RoundInt()
+
+	// challenge threshold can't be less than min challenge stake
+	if challengeThresholdAmount.LT(params.MinChallengeStake) {
+		return sdk.NewCoin(totalBackingAmount.Denom, params.MinChallengeStake)
+	}
 
 	return sdk.NewCoin(totalBackingAmount.Denom, challengeThresholdAmount)
 }

--- a/x/game/keeper_test.go
+++ b/x/game/keeper_test.go
@@ -175,6 +175,17 @@ func Test_challengeThresholdNoBacking(t *testing.T) {
 	assert.Equal(t, "10trudex", amt.String())
 }
 
+// challenge threshold should not go below min challenge stake
+// if challenge threshold is 1/3 of backing and min challenge stake is 10
+// when a story has backing amount of 21, challenge threshold should be 10, not 7
+// then instead
+func Test_challengeThresholdWithSmallBacking(t *testing.T) {
+	_, k, _ := mockDB()
+	amt := k.ChallengeThreshold(sdk.NewCoin("trudex", sdk.NewInt(21)))
+
+	assert.Equal(t, "10trudex", amt.String())
+}
+
 func Test_challengeThresholdWithBacking(t *testing.T) {
 	_, k, _ := mockDB()
 	amt := k.ChallengeThreshold(sdk.NewCoin("trudex", sdk.NewInt(100)))


### PR DESCRIPTION
I believe the challenge threshold should not be below 10, which is the min stake amount.

![img_0001](https://user-images.githubusercontent.com/43760810/50580901-43699c00-0e09-11e9-99e7-7c7fb455fc82.PNG)
