### PR TITLE
Add unit to Coin resolver

### DIFF
--- a/.chain/graphql-schema.json
+++ b/.chain/graphql-schema.json
@@ -500,35 +500,28 @@
                 "ofType": null
               }
             }
-          }
-        ],
-        "inputFields": [],
-        "interfaces": [],
-        "kind": "OBJECT",
-        "name": "Coin",
-        "possibleTypes": []
-      },
-      {
-        "description": "",
-        "enumValues": [],
-        "fields": [
+          },
           {
             "args": [],
             "deprecationReason": "",
             "description": "",
             "isDeprecated": false,
-            "name": "int",
+            "name": "unit",
             "type": {
-              "kind": "OBJECT",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": "",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "string",
+                "ofType": null
+              }
             }
           }
         ],
         "inputFields": [],
         "interfaces": [],
         "kind": "OBJECT",
-        "name": "Dec",
+        "name": "Coin",
         "possibleTypes": []
       },
       {
@@ -796,13 +789,13 @@
             "deprecationReason": "",
             "description": "",
             "isDeprecated": false,
-            "name": "amountWeight",
+            "name": "backingMaxDuration",
             "type": {
               "kind": "NON_NULL",
               "name": "",
               "ofType": {
-                "kind": "OBJECT",
-                "name": "Dec",
+                "kind": "SCALAR",
+                "name": "int64",
                 "ofType": null
               }
             }
@@ -812,13 +805,13 @@
             "deprecationReason": "",
             "description": "",
             "isDeprecated": false,
-            "name": "maxInterestRate",
+            "name": "backingMinDuration",
             "type": {
               "kind": "NON_NULL",
               "name": "",
               "ofType": {
-                "kind": "OBJECT",
-                "name": "Dec",
+                "kind": "SCALAR",
+                "name": "int64",
                 "ofType": null
               }
             }
@@ -828,29 +821,13 @@
             "deprecationReason": "",
             "description": "",
             "isDeprecated": false,
-            "name": "minInterestRate",
+            "name": "challengeMinStake",
             "type": {
               "kind": "NON_NULL",
               "name": "",
               "ofType": {
                 "kind": "OBJECT",
-                "name": "Dec",
-                "ofType": null
-              }
-            }
-          },
-          {
-            "args": [],
-            "deprecationReason": "",
-            "description": "",
-            "isDeprecated": false,
-            "name": "periodWeight",
-            "type": {
-              "kind": "NON_NULL",
-              "name": "",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Dec",
+                "name": "Int",
                 "ofType": null
               }
             }

--- a/x/truapi/truapi.go
+++ b/x/truapi/truapi.go
@@ -111,6 +111,7 @@ func (ta *TruAPI) RegisterResolvers() {
 	ta.GraphQLClient.RegisterObjectResolver("Coin", sdk.Coin{}, map[string]interface{}{
 		"amount": func(_ context.Context, q sdk.Coin) string { return q.Amount.String() },
 		"denom":  func(_ context.Context, q sdk.Coin) string { return q.Denom },
+		"unit":   func(_ context.Context, q sdk.Coin) string { return "preethi" },
 	})
 
 	ta.GraphQLClient.RegisterObjectResolver("Evidence", story.Evidence{}, map[string]interface{}{


### PR DESCRIPTION
I planned to eventually just hack some middleware into the ApolloClient to append the unit, but thought maybe that was too much magic and maybe it should come explicitly from graphQL. all denominations coming from the server will be in preethis, that's why I hardcoded it.