### PR TITLE
Fixed the name of the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 2. Now let's install truchain.
 
 ``` bash
-mkdir -p $GOPATH/src/github.com/trustory
+# Go dependencies are case-sensitive.
+# The directory name must have the characters T and S in capital to match the name of this repo.
+mkdir -p $GOPATH/src/github.com/TruStory
 
-cd $GOPATH/src/github.com/trustory
+cd $GOPATH/src/github.com/TruStory
 
 git clone https://github.com/TruStory/truchain.git
 


### PR DESCRIPTION
Because the Go dependencies are case-sensitive, the folder's name must match with the repo's name. Otherwise, `dep` will put a copy of the repo in the `vendor` folder and will use it for building rather than the actual codebase.

Spent 4+ hours to realize what wrong was happening, and this statement in the installation step turned out to be the culprit. Fixed it for everyone in future.