### PR TITLE
Sorted initial coins

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -167,5 +167,14 @@ func (app *TruChain) initialCoins() sdk.Coins {
 
 	coins = append(coins, params.InitialTruStake)
 
-	return coins.Sort()
+	// coins need to be sorted by denom to be valid
+	coins.Sort()
+
+	// yes we should panic if coins aren't valid
+	// as it undermines the whole chain
+	if !coins.IsValid() {
+		panic("Initial coins are not valid.")
+	}
+
+	return coins
 }


### PR DESCRIPTION
Fixes #304. Fixes https://github.com/TruStory/TruStory-mobile/issues/305.

Cosmos requires multiple denomination coins be sorted by denom name. All the coin math assumes they are. This wasn't documented anywhere. Had to dig into the framework source to figure out.

Didn't run into this before because coins added via the bank keeper sorts them for us. It failed for initial coins because we were setting the coins ourselves, without sorting.

Such is life living on the edge!
