### PR TITLE
Fixed backing vote tallying

### DIFF
--- a/x/backing/keeper.go
+++ b/x/backing/keeper.go
@@ -275,19 +275,22 @@ func (k Keeper) Tally(
 	ctx sdk.Context, storyID int64) (
 	trueVotes []Backing, falseVotes []Backing, err sdk.Error) {
 
-	err = k.backingStoryList.Map(ctx, k, storyID, func(backingID int64) sdk.Error {
-		backing, err := k.Backing(ctx, backingID)
+	// iterate through unmatured backings
+	var ID int64
+	k.backingList(ctx).Iterate(&ID, func(index uint64) bool {
+		backing, err := k.Backing(ctx, ID)
 		if err != nil {
-			return err
+			panic(err)
 		}
 
-		if backing.VoteChoice() == true {
-			trueVotes = append(trueVotes, backing)
-		} else {
-			falseVotes = append(falseVotes, backing)
+		if backing.StoryID == storyID {
+			if backing.VoteChoice() == true {
+				trueVotes = append(trueVotes, backing)
+			} else {
+				falseVotes = append(falseVotes, backing)
+			}
 		}
-
-		return nil
+		return false
 	})
 
 	return


### PR DESCRIPTION
Fixes #348.

Accounts for matured backings. Not the most efficient way to do this. Focusing on making things work over efficiency right now.

