### PR TITLE
Temporarily disable ante-handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -216,7 +216,9 @@ func NewTruChain(logger log.Logger, db dbm.DB, options ...func(*bam.BaseApp)) *T
 	)
 
 	// The AnteHandler handles signature verification and transaction pre-processing
-	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper))
+	// TODO [shanev]: see https://github.com/TruStory/truchain/issues/364
+	// Add this back after fixing issues with signature verification
+	// app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper))
 
 	// The app.Router is the main transaction router where each module registers its routes
 	app.Router().


### PR DESCRIPTION
This disables the ante-handler, where signature verification is done and fees are collected. This is fine for MVP, but needs to be added back in after https://github.com/TruStory/TruStory-mobile/issues/296 is resolved.

Created https://github.com/TruStory/truchain/issues/364 to track this.