### PR TITLE
Distributing rewards evenly to backers and voters

### DIFF
--- a/x/vote/tally_test.go
+++ b/x/vote/tally_test.go
@@ -80,6 +80,15 @@ func TestConfirmedStoryRewardPool(t *testing.T) {
 	assert.Equal(t, "5500000000000trusteak", pool.String())
 }
 
+func TestConfirmedStoryRewardPool2(t *testing.T) {
+	ctx, votes, _ := fakeValidationGame2()
+
+	pool := sdk.NewCoin(params.StakeDenom, sdk.ZeroInt())
+
+	confirmedPool(ctx, votes.falseVotes, &pool)
+	assert.Equal(t, "265000000000trusteak", pool.String())
+}
+
 func TestDistributeRewardsConfirmed(t *testing.T) {
 	ctx, votes, k := fakeValidationGame()
 	pool := sdk.NewCoin(params.StakeDenom, sdk.ZeroInt())
@@ -96,27 +105,27 @@ func TestDistributeRewardsConfirmed(t *testing.T) {
 	winningBacker1 := votes.trueVotes[0].(backing.Backing)
 	coins = k.bankKeeper.GetCoins(ctx, winningBacker1.Creator())
 	assert.Equal(t, "2000000000000", coins.AmountOf(params.StakeDenom).String())
-	assert.Equal(t, "500000000000", coins.AmountOf(cred).String())
+	assert.Equal(t, "1416666666666", coins.AmountOf(cred).String())
 
 	winningBacker2 := votes.trueVotes[1].(backing.Backing)
 	coins = k.bankKeeper.GetCoins(ctx, winningBacker2.Creator())
 	assert.Equal(t, "2000000000000", coins.AmountOf(params.StakeDenom).String())
-	assert.Equal(t, "500000000000", coins.AmountOf(cred).String())
+	assert.Equal(t, "1416666666666", coins.AmountOf(cred).String())
 
 	winningBacker3 := votes.trueVotes[2].(backing.Backing)
 	coins = k.bankKeeper.GetCoins(ctx, winningBacker3.Creator())
 	assert.Equal(t, "2000000000000", coins.AmountOf(params.StakeDenom).String())
-	assert.Equal(t, "500000000000", coins.AmountOf(cred).String())
+	assert.Equal(t, "1416666666666", coins.AmountOf(cred).String())
 
 	winningVoter1 := votes.trueVotes[3].(TokenVote)
 	coins = k.bankKeeper.GetCoins(ctx, winningVoter1.Creator())
 	assert.Equal(t, "2000000000000", coins.AmountOf(params.StakeDenom).String())
-	assert.Equal(t, "1833333333333", coins.AmountOf(cred).String())
+	assert.Equal(t, "916666666666", coins.AmountOf(cred).String())
 
 	winningVoter2 := votes.trueVotes[4].(TokenVote)
 	coins = k.bankKeeper.GetCoins(ctx, winningVoter2.Creator())
 	assert.Equal(t, "2000000000000", coins.AmountOf(params.StakeDenom).String())
-	assert.Equal(t, "1833333333333", coins.AmountOf(cred).String())
+	assert.Equal(t, "916666666666", coins.AmountOf(cred).String())
 
 	losingBacker1 := votes.falseVotes[0].(backing.Backing)
 	coins = k.bankKeeper.GetCoins(ctx, losingBacker1.Creator())
@@ -141,6 +150,50 @@ func TestDistributeRewardsConfirmed(t *testing.T) {
 	losingVoter1 := votes.falseVotes[4].(TokenVote)
 	coins = k.bankKeeper.GetCoins(ctx, losingVoter1.Creator())
 	assert.Equal(t, "1000000000000", coins.AmountOf(params.StakeDenom).String())
+	assert.Equal(t, "0", coins.AmountOf(cred).String())
+}
+
+func TestDistributeRewardsConfirmed2(t *testing.T) {
+	ctx, votes, k := fakeValidationGame2()
+	pool := sdk.NewCoin(params.StakeDenom, sdk.ZeroInt())
+	confirmedPool(ctx, votes.falseVotes, &pool)
+
+	cred := "trudex"
+
+	err := distributeRewardsConfirmed(
+		ctx, k.backingKeeper, k.bankKeeper, votes, pool, cred)
+	assert.Nil(t, err)
+
+	coins := sdk.Coins{}
+
+	winningBacker1 := votes.trueVotes[0].(backing.Backing)
+	coins = k.bankKeeper.GetCoins(ctx, winningBacker1.Creator())
+	assert.Equal(t, "2000000000000", coins.AmountOf(params.StakeDenom).String())
+	assert.Equal(t, "95003666333", coins.AmountOf(cred).String())
+
+	winningBacker2 := votes.trueVotes[1].(backing.Backing)
+	coins = k.bankKeeper.GetCoins(ctx, winningBacker2.Creator())
+	assert.Equal(t, "2000000000000", coins.AmountOf(params.StakeDenom).String())
+	assert.Equal(t, "92001934065", coins.AmountOf(cred).String())
+
+	winningBacker3 := votes.trueVotes[2].(backing.Backing)
+	coins = k.bankKeeper.GetCoins(ctx, winningBacker3.Creator())
+	assert.Equal(t, "2000000000000", coins.AmountOf(params.StakeDenom).String())
+	assert.Equal(t, "95003666333", coins.AmountOf(cred).String())
+
+	losingChallenger1 := votes.falseVotes[0].(challenge.Challenge)
+	coins = k.bankKeeper.GetCoins(ctx, losingChallenger1.Creator())
+	assert.Equal(t, "1828000000000", coins.AmountOf(params.StakeDenom).String())
+	assert.Equal(t, "0", coins.AmountOf(cred).String())
+
+	losingChallenger2 := votes.falseVotes[1].(challenge.Challenge)
+	coins = k.bankKeeper.GetCoins(ctx, losingChallenger2.Creator())
+	assert.Equal(t, "1917000000000", coins.AmountOf(params.StakeDenom).String())
+	assert.Equal(t, "0", coins.AmountOf(cred).String())
+
+	losingChallenger3 := votes.falseVotes[2].(challenge.Challenge)
+	coins = k.bankKeeper.GetCoins(ctx, losingChallenger3.Creator())
+	assert.Equal(t, "1990000000000", coins.AmountOf(params.StakeDenom).String())
 	assert.Equal(t, "0", coins.AmountOf(cred).String())
 }
 

--- a/x/vote/test_common.go
+++ b/x/vote/test_common.go
@@ -229,3 +229,55 @@ func fakeValidationGame() (ctx sdk.Context, votes poll, k Keeper) {
 
 	return
 }
+
+func fakeValidationGame2() (ctx sdk.Context, votes poll, k Keeper) {
+	ctx, k, ck := mockDB()
+
+	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	amount1 := sdk.NewCoin(params.StakeDenom, sdk.NewInt(100000000000))
+	amount2 := sdk.NewCoin(params.StakeDenom, sdk.NewInt(55000000000))
+	amount3 := sdk.NewCoin(params.StakeDenom, sdk.NewInt(172000000000))
+	amount4 := sdk.NewCoin(params.StakeDenom, sdk.NewInt(83000000000))
+	amount5 := sdk.NewCoin(params.StakeDenom, sdk.NewInt(10000000000))
+	argument := "test argument"
+
+	creator1 := fakeFundedCreator(ctx, k.bankKeeper)
+	creator2 := fakeFundedCreator(ctx, k.bankKeeper)
+	creator3 := fakeFundedCreator(ctx, k.bankKeeper)
+	creator5 := fakeFundedCreator(ctx, k.bankKeeper)
+	creator6 := fakeFundedCreator(ctx, k.bankKeeper)
+	creator10 := fakeFundedCreator(ctx, k.bankKeeper)
+
+	// fake backings
+	duration := 1 * time.Hour
+	b1id, _ := k.backingKeeper.Create(ctx, storyID, amount1, argument, creator1, duration)
+	b2id, _ := k.backingKeeper.Create(ctx, storyID, amount2, argument, creator2, duration)
+	b3id, _ := k.backingKeeper.Create(ctx, storyID, amount1, argument, creator3, duration)
+
+	// fake challenges
+	c1id, _ := k.challengeKeeper.Create(ctx, storyID, amount3, argument, creator5)
+	c2id, _ := k.challengeKeeper.Create(ctx, storyID, amount4, argument, creator6)
+	c3id, _ := k.challengeKeeper.Create(ctx, storyID, amount5, argument, creator10)
+
+	b1, _ := k.backingKeeper.Backing(ctx, b1id)
+	cred := "trudex"
+	b1.Interest = sdk.NewCoin(cred, sdk.NewInt(6670333000))
+	k.backingKeeper.Update(ctx, b1)
+
+	b2, _ := k.backingKeeper.Backing(ctx, b2id)
+	b2.Interest = sdk.NewCoin(cred, sdk.NewInt(3668600732))
+	k.backingKeeper.Update(ctx, b2)
+
+	b3, _ := k.backingKeeper.Backing(ctx, b3id)
+	b3.Interest = sdk.NewCoin(cred, sdk.NewInt(6670333000))
+	k.backingKeeper.Update(ctx, b3)
+
+	c1, _ := k.challengeKeeper.Challenge(ctx, c1id)
+	c2, _ := k.challengeKeeper.Challenge(ctx, c2id)
+	c3, _ := k.challengeKeeper.Challenge(ctx, c3id)
+
+	votes.trueVotes = append(votes.trueVotes, b1, b2, b3)
+	votes.falseVotes = append(votes.falseVotes, c1, c2, c3)
+
+	return
+}


### PR DESCRIPTION
Fixes #374.

Fixed case when there are no token voters for a confirmed story.

