### PR TITLE
Allow truchain to serve Trustory React web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ node_modules/
 .DS_Store
 ./registrar.key
 .env
+web/
 
 # These stay ignored until we switch to modules
 go.mod

--- a/x/truapi/truapi.go
+++ b/x/truapi/truapi.go
@@ -51,6 +51,13 @@ func (ta *TruAPI) RegisterModels() {
 
 // RegisterRoutes applies the TruStory API routes to the `chttp.API` router
 func (ta *TruAPI) RegisterRoutes() {
+	// Register routes for Trustory React web app
+	fs := http.FileServer(http.Dir("web/static"))
+	http.Handle("/static/", http.StripPrefix("/static/", fs))
+	http.HandleFunc("/web/", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "web/index.html")
+	})
+
 	ta.Use(chttp.JSONResponseMiddleware)
 	http.Handle("/graphql", thunder.Handler(ta.GraphQLClient.Schema))
 	http.Handle("/graphiql/", http.StripPrefix("/graphiql/", graphiql.Handler()))


### PR DESCRIPTION
Just thought I'd start the conversation about hosting the trustory web app.

This is one approach which is simple. We have the truchain api serve the React files at `/web/` path for now.

May need to use a configuration file to set the path to the web files so it works in various environments...