### PR TITLE
Fix deployment script to only rebuild and update truchain if new changes exist

### DIFF
--- a/ops/build-aws.sh
+++ b/ops/build-aws.sh
@@ -6,20 +6,30 @@ PATH=/home/ubuntu/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin
 GOPATH=/home/ubuntu/go
 cd "${GOPATH}/src/github.com/TruStory/truchain"
 
+COMMIT_BEFORE_PULL=$(git rev-parse HEAD)
+
 # get repo
-git pull || echo "git pull failed."
+git pull > /dev/null
 
-# build node
-make update_deps
-make buidl
+COMMIT_AFTER_PULL=$(git rev-parse HEAD)
 
-# stop truchaind daemon
-sudo systemctl stop truchaind.service
+# if new commits on branch, update and restart truchain service
+if [ "$COMMIT_BEFORE_PULL" != "$COMMIT_AFTER_PULL" ]
+then
 
-# copy files
-cp bin/truchaind $GOPATH/bin
-cp bin/trucli $GOPATH/bin
-cp .chain/bootstrap.csv ~/.truchaind/bootstrap.csv
+  # build node
+  make update_deps
+  make buidl
 
-# start truchain daemon
-sudo systemctl start truchaind.service
+  # stop truchaind daemon
+  sudo systemctl stop truchaind.service
+
+  # copy files
+  cp bin/truchaind $GOPATH/bin
+  cp bin/trucli $GOPATH/bin
+  cp .chain/bootstrap.csv ~/.truchaind/bootstrap.csv
+
+  # start truchain daemon
+  sudo systemctl start truchaind.service
+
+fi


### PR DESCRIPTION
Now that we use gitflow, I would like to re-enable the automatic deployment of truchain from master. 

We turned it off before because the cronjob on the server was rebuilding and restarting the Go server every 5 minutes, regardless if there were new changes to deploy.  This would cause the mobile app to encounter unexpected network errors while the server was restarting.

This is a fix that only updates and restarts the go server if there are new commits on master.