### PR TITLE
Fixed check story state for new vote

### DIFF
--- a/x/vote/handler_test.go
+++ b/x/vote/handler_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/TruStory/truchain/x/story"
+
 	"github.com/TruStory/truchain/types"
 	app "github.com/TruStory/truchain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,7 +18,7 @@ func TestCreateVoteMsg(t *testing.T) {
 	h := NewHandler(k)
 	assert.NotNil(t, h)
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Pending)
 	amount := sdk.NewCoin(app.StakeDenom, sdk.NewInt(15000000000))
 	creator := sdk.AccAddress([]byte{1, 2})
 

--- a/x/vote/keeper_test.go
+++ b/x/vote/keeper_test.go
@@ -3,6 +3,8 @@ package vote
 import (
 	"testing"
 
+	"github.com/TruStory/truchain/x/story"
+
 	app "github.com/TruStory/truchain/types"
 	"github.com/TruStory/truchain/x/stake"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,7 +14,7 @@ import (
 func TestCreateGetVote(t *testing.T) {
 	ctx, k, ck := mockDB()
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Pending)
 	amount := sdk.NewCoin(app.StakeDenom, sdk.NewInt(15000000000))
 	comment := "test comment is long enough"
 	creator := sdk.AccAddress([]byte{1, 2})
@@ -34,7 +36,7 @@ func TestCreateGetVote(t *testing.T) {
 func TestInValidCreateVoteMsgArgumentTooShort(t *testing.T) {
 	ctx, k, ck := mockDB()
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Challenged)
 	amount := sdk.NewCoin(app.StakeDenom, sdk.NewInt(15000000000))
 	creator := sdk.AccAddress([]byte{1, 2})
 
@@ -50,7 +52,7 @@ func TestInValidCreateVoteMsgArgumentTooShort(t *testing.T) {
 func TestInValidCreateVoteMsgArgumentTooLong(t *testing.T) {
 	ctx, k, ck := mockDB()
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Challenged)
 	amount := sdk.NewCoin(app.StakeDenom, sdk.NewInt(15000000000))
 	creator := sdk.AccAddress([]byte{1, 2})
 
@@ -66,7 +68,7 @@ func TestInValidCreateVoteMsgArgumentTooLong(t *testing.T) {
 func TestGetVotesByGameID(t *testing.T) {
 	ctx, k, ck := mockDB()
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Pending)
 	amount := sdk.NewCoin(app.StakeDenom, sdk.NewInt(15000000000))
 	comment := "test comment is long enough"
 	creator := sdk.AccAddress([]byte{1, 2})
@@ -95,7 +97,7 @@ func TestGetVotesByGameID(t *testing.T) {
 func TestGetVotesByStoryIDAndCreator(t *testing.T) {
 	ctx, k, ck := mockDB()
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Pending)
 	amount := sdk.NewCoin(app.StakeDenom, sdk.NewInt(15000000000))
 	comment := "test comment is long enough"
 	creator := sdk.AccAddress([]byte{1, 2})
@@ -117,7 +119,7 @@ func TestGetVotesByStoryIDAndCreator(t *testing.T) {
 func TestTotalVoteAmountByGameID(t *testing.T) {
 	ctx, k, ck := mockDB()
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Pending)
 	amount := sdk.NewCoin(app.StakeDenom, sdk.NewInt(15000000000))
 	comment := "test comment is long enough"
 	creator := sdk.AccAddress([]byte{1, 2})
@@ -146,7 +148,7 @@ func TestTotalVoteAmountByGameID(t *testing.T) {
 func TestCreateVote_ErrGameNotStarted(t *testing.T) {
 	ctx, k, ck := mockDB()
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Pending)
 	amount := sdk.NewCoin(app.StakeDenom, sdk.NewInt(50000000000000))
 	comment := "test comment is long enough"
 	creator := sdk.AccAddress([]byte{1, 2})
@@ -161,7 +163,7 @@ func TestCreateVote_ErrGameNotStarted(t *testing.T) {
 func TestCreateVote_ErrBelowMinStake(t *testing.T) {
 	ctx, k, ck := mockDB()
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Challenged)
 	amount := sdk.NewCoin(app.StakeDenom, sdk.NewInt(5000000))
 	comment := "test comment is long enough"
 	creator := sdk.AccAddress([]byte{1, 2})
@@ -170,4 +172,5 @@ func TestCreateVote_ErrBelowMinStake(t *testing.T) {
 
 	_, err := k.Create(ctx, storyID, amount, vote, comment, creator)
 	assert.NotNil(t, err)
+	assert.Equal(t, sdk.ErrInsufficientFunds("Below minimum stake.").Code(), err.Code())
 }

--- a/x/vote/msg_test.go
+++ b/x/vote/msg_test.go
@@ -3,6 +3,7 @@ package vote
 import (
 	"testing"
 
+	"github.com/TruStory/truchain/x/story"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -10,7 +11,7 @@ import (
 func TestValidCreateVoteMsg(t *testing.T) {
 	ctx, k, ck := mockDB()
 
-	storyID := createFakeStory(ctx, k.storyKeeper, ck)
+	storyID := createFakeStory(ctx, k.storyKeeper, ck, story.Pending)
 	amount := sdk.NewCoin("testcoin", sdk.NewInt(5))
 	creator := sdk.AccAddress([]byte{1, 2})
 

--- a/x/vote/test_common.go
+++ b/x/vote/test_common.go
@@ -136,7 +136,7 @@ func mockDB() (sdk.Context, Keeper, c.Keeper) {
 	return ctx, k, ck
 }
 
-func createFakeStory(ctx sdk.Context, sk story.WriteKeeper, ck c.WriteKeeper) int64 {
+func createFakeStory(ctx sdk.Context, sk story.WriteKeeper, ck c.WriteKeeper, st story.State) int64 {
 	body := "TruStory validators can be bootstrapped with a single genesis file."
 	cat := createFakeCategory(ctx, ck)
 	creator := sdk.AccAddress([]byte{1, 2})
@@ -144,10 +144,9 @@ func createFakeStory(ctx sdk.Context, sk story.WriteKeeper, ck c.WriteKeeper) in
 	source := url.URL{}
 
 	storyID, _ := sk.Create(ctx, body, cat.ID, creator, source, storyType)
-	// TODO [shanev]: https://github.com/TruStory/truchain/issues/407
-	// s, _ := sk.Story(ctx, storyID)
-	// s.State = story.Challenged
-	// sk.UpdateStory(ctx, s)
+	s, _ := sk.Story(ctx, storyID)
+	s.State = st
+	sk.UpdateStory(ctx, s)
 
 	return storyID
 }


### PR DESCRIPTION
Fixes #407 

The story already validated the state after a few checks and returning `ErrVotingNotStarted` I've moved the logic to be the first check and  utilizes `currentStory` avoiding having to retrieve the story twice through  `validateStoryState`
