### PR TITLE
Updated command to download dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test_cover: set_registrar set_env_vars
 update_deps:
 	@echo "--> Running dep ensure"
 	@rm -rf .vendor-new
-	@dep ensure -v
+	@dep ensure -v -vendor-only
 
 .PHONY: benchmark buidl build check dep_graph test test_cover update_deps
 


### PR DESCRIPTION
The `-vendor-only` flag ensures the dependencies used are the exact same version as in the `.lock` file and does not try to update any of its dependencies and prevents from modifying  the `.lock` file, very important for CI and for building it on the server. 