### PR TITLE
Add resolver for all addresses that flagged a story

### DIFF
--- a/.chain/graphql-schema.json
+++ b/.chain/graphql-schema.json
@@ -1627,6 +1627,30 @@
             "deprecationReason": "",
             "description": "",
             "isDeprecated": false,
+            "name": "addressesWhoFlagged",
+            "type": {
+              "kind": "NON_NULL",
+              "name": "",
+              "ofType": {
+                "kind": "LIST",
+                "name": "",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              }
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
             "name": "backingPool",
             "type": {
               "kind": "NON_NULL",

--- a/x/truapi/resolver.go
+++ b/x/truapi/resolver.go
@@ -364,6 +364,18 @@ func (ta *TruAPI) notificationsResolver(ctx context.Context, q struct{}) []db.No
 	return evts
 }
 
+func (ta *TruAPI) addressesWhoFlaggedResolver(ctx context.Context, q story.Story) []string {
+	flaggedStories, err := ta.DBClient.FlaggedStoriesByStoryID(q.ID)
+	if err != nil {
+		return []string{}
+	}
+	var addressesWhoFlagged []string
+	for _, story := range flaggedStories {
+		addressesWhoFlagged = append(addressesWhoFlagged, story.Creator)
+	}
+	return addressesWhoFlagged
+}
+
 func (ta *TruAPI) filterFlaggedStories(stories *[]story.Story) ([]story.Story, error) {
 	val := os.Getenv("FLAGGED_STORY_LIMIT")
 	if val == "" {

--- a/x/truapi/truapi.go
+++ b/x/truapi/truapi.go
@@ -264,18 +264,19 @@ func (ta *TruAPI) RegisterResolvers() {
 	ta.GraphQLClient.RegisterQueryResolver("stories", ta.allStoriesResolver)
 	ta.GraphQLClient.RegisterQueryResolver("story", ta.storyResolver)
 	ta.GraphQLClient.RegisterObjectResolver("Story", story.Story{}, map[string]interface{}{
-		"id":              func(_ context.Context, q story.Story) int64 { return q.ID },
-		"backings":        func(ctx context.Context, q story.Story) []backing.Backing { return getBackings(ctx, q.ID) },
-		"challenges":      func(ctx context.Context, q story.Story) []challenge.Challenge { return getChallenges(ctx, q.ID) },
-		"backingPool":     ta.backingPoolResolver,
-		"challengePool":   ta.challengePoolResolver,
-		"category":        ta.storyCategoryResolver,
-		"creator":         func(ctx context.Context, q story.Story) users.User { return getUser(ctx, q.Creator) },
-		"source":          func(ctx context.Context, q story.Story) string { return q.Source.String() },
-		"state":           func(ctx context.Context, q story.Story) story.Status { return q.Status },
-		"expireTime":      func(_ context.Context, q story.Story) string { return formatTime(q.ExpireTime) },
-		"votingStartTime": func(_ context.Context, q story.Story) string { return formatTime(q.VotingStartTime) },
-		"votingEndTime":   func(_ context.Context, q story.Story) string { return formatTime(q.VotingEndTime) },
+		"id":                  func(_ context.Context, q story.Story) int64 { return q.ID },
+		"backings":            func(ctx context.Context, q story.Story) []backing.Backing { return getBackings(ctx, q.ID) },
+		"challenges":          func(ctx context.Context, q story.Story) []challenge.Challenge { return getChallenges(ctx, q.ID) },
+		"backingPool":         ta.backingPoolResolver,
+		"challengePool":       ta.challengePoolResolver,
+		"category":            ta.storyCategoryResolver,
+		"creator":             func(ctx context.Context, q story.Story) users.User { return getUser(ctx, q.Creator) },
+		"source":              func(ctx context.Context, q story.Story) string { return q.Source.String() },
+		"state":               func(ctx context.Context, q story.Story) story.Status { return q.Status },
+		"expireTime":          func(_ context.Context, q story.Story) string { return formatTime(q.ExpireTime) },
+		"votingStartTime":     func(_ context.Context, q story.Story) string { return formatTime(q.VotingStartTime) },
+		"votingEndTime":       func(_ context.Context, q story.Story) string { return formatTime(q.VotingEndTime) },
+		"addressesWhoFlagged": ta.addressesWhoFlaggedResolver,
 	})
 
 	ta.GraphQLClient.RegisterObjectResolver("Timestamp", app.Timestamp{}, map[string]interface{}{


### PR DESCRIPTION
- This is part of a two-part PR to indicate to users if they already flagged a story
- Resolver fetches the addresses of all users who have flagged the story
- The addresses are then used on the client to either display 'Flag Claim' or 'You have Flagged this Claim' depending on if they acted already or not.