### PR TITLE
Add search filter to stories feed query

### DIFF
--- a/x/graphql/graphql.go
+++ b/x/graphql/graphql.go
@@ -64,6 +64,11 @@ func (c *Client) RegisterPaginatedQueryResolver(name string, fn interface{}) {
 	c.queries.FieldFunc(name, fn, builder.Paginated)
 }
 
+// RegisterPaginatedQueryResolverWithFilter adds a top-level resolver to find the first paginated batch of entities in a GraphQL query filtered by content
+func (c *Client) RegisterPaginatedQueryResolverWithFilter(name string, fn interface{}, filter map[string]interface{}) {
+	c.queries.FieldFunc(name, fn, builder.Paginated, builder.TextFilterFields(filter))
+}
+
 // RegisterMutation registers a mutation
 func (c *Client) RegisterMutation(name string, fn interface{}) {
 	c.mutations.FieldFunc(name, fn)

--- a/x/truapi/truapi.go
+++ b/x/truapi/truapi.go
@@ -329,7 +329,10 @@ func (ta *TruAPI) RegisterResolvers() {
 		"challengeThresholdPercent": func(_ context.Context, p params.Params) string { return "0" },
 	})
 
-	ta.GraphQLClient.RegisterPaginatedQueryResolver("paginated_stories", ta.storiesResolver)
+	ta.GraphQLClient.RegisterPaginatedQueryResolverWithFilter("paginated_stories", ta.storiesResolver, map[string]interface{}{
+		"body": func(_ context.Context, q story.Story) string { return q.Body },
+	})
+
 	ta.GraphQLClient.RegisterQueryResolver("story", ta.storyResolver)
 	ta.GraphQLClient.RegisterPaginatedObjectResolver("Story", "iD", story.Story{}, map[string]interface{}{
 		"id":                  func(_ context.Context, q story.Story) int64 { return q.ID },


### PR DESCRIPTION
Fixes #572 . Adds a "filterText" argument to paginated stories query. Only returns stories whose body contains "filterText" in paginated fashion:

```
paginated_stories(categoryID: -1, filterText: "bitcoin")
```

<img width="993" alt="Screen Shot 2019-05-07 at 8 45 48 AM" src="https://user-images.githubusercontent.com/43760810/57313487-9055cb80-70a4-11e9-824f-90108440fc43.png">
