### PR TITLE
Update README.md

### DIFF
--- a/docs/spec/claim/README.md
+++ b/docs/spec/claim/README.md
@@ -14,14 +14,15 @@ The claim module's responsibility is to create and store claims. Claims are the 
 
 ```go
 type Claim struct {
-    ID              int64
-    CommunityID     int64
-    Body            string
-    Creator         sdk.AccAddress
-    Source          url.URL
-    TotalBacked     sdk.Coin
-    TotalChallenged sdk.Coin
-    CreatedTime     time.Time
+    ID                  int64
+    CommunityID         int64
+    Body                string
+    Creator             sdk.AccAddress
+    Source              url.URL
+    TotalParticipants   int64
+    TotalBackingStake   sdk.Coin
+    TotalChallengeStake sdk.Coin
+    CreatedTime         time.Time
 }
 
 // Params can be voted on by governance


### PR DESCRIPTION
For trending feeds we use total number of participants. Right now you would need to fetch a claim, iterate through claim arguments and then iterate over staking lists for each argument. I though since we're keeping the `Total(Backing/Challenge)Stake` on the claim, we might as well include the `TotalParticipants`.

Also, I'm not sure if we want to follow this convention or not, but we could suffix the word `Stake` whenever we refer to sdk.Coin's.