### PR TITLE
New Auth Module

### DIFF
--- a/x/auth/codec.go
+++ b/x/auth/codec.go
@@ -1,0 +1,20 @@
+package auth
+
+import "github.com/cosmos/cosmos-sdk/codec"
+
+// RegisterCodec registers all the necessary types and interfaces for the module
+func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterConcrete(MsgRegisterKey{}, "truchain/MsgRegisterKey", nil)
+
+	cdc.RegisterConcrete(AppAccount{}, "truchain/AppAccount", nil)
+}
+
+// ModuleCodec encodes module codec
+var ModuleCodec *codec.Codec
+
+func init() {
+	ModuleCodec = codec.New()
+	RegisterCodec(ModuleCodec)
+	codec.RegisterCrypto(ModuleCodec)
+	ModuleCodec.Seal()
+}

--- a/x/auth/common_test.go
+++ b/x/auth/common_test.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkAuth "github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto"
+	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+	dbm "github.com/tendermint/tendermint/libs/db"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+// interface conformance check
+var _ BankKeeper = bankKeeper{}
+
+type transaction struct {
+	Address sdk.Address
+	Coins   sdk.Coins
+}
+type bankKeeper struct {
+	Transactions []transaction
+}
+
+// NewTransaction ...
+func (bk bankKeeper) NewTransaction(ctx sdk.Context, to sdk.AccAddress, coins sdk.Coins) bool {
+	txn := transaction{to, coins}
+	bk.Transactions = append(bk.Transactions, txn)
+	return true
+}
+
+func mockDB() (sdk.Context, Keeper) {
+	db := dbm.NewMemDB()
+
+	authKey := sdk.NewKVStoreKey(ModuleName)
+	accountKey := sdk.NewKVStoreKey(sdkAuth.StoreKey)
+	paramsKey := sdk.NewKVStoreKey(params.StoreKey)
+	transientParamsKey := sdk.NewTransientStoreKey(params.TStoreKey)
+
+	ms := store.NewCommitMultiStore(db)
+	ms.MountStoreWithDB(authKey, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(accountKey, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(paramsKey, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(transientParamsKey, sdk.StoreTypeTransient, db)
+	ms.LoadLatestVersion()
+
+	ctx := sdk.NewContext(ms, abci.Header{}, false, log.NewNopLogger())
+
+	codec := codec.New()
+	cryptoAmino.RegisterAmino(codec)
+	RegisterCodec(codec)
+
+	paramsKeeper := params.NewKeeper(codec, paramsKey, transientParamsKey, params.DefaultCodespace)
+	bankKeeper := bankKeeper{
+		Transactions: []transaction{},
+	}
+	accountKeeper := sdkAuth.NewAccountKeeper(codec, accountKey, paramsKeeper.Subspace(sdkAuth.DefaultParamspace), sdkAuth.ProtoBaseAccount)
+	authKeeper := NewKeeper(authKey, paramsKeeper.Subspace(ModuleName), codec, bankKeeper, accountKeeper)
+
+	InitGenesis(ctx, authKeeper, DefaultGenesisState())
+
+	// setting registrar
+	params := authKeeper.GetParams(ctx)
+	params.Registrar = sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()) // creating a new key
+	authKeeper.SetParams(ctx, params)
+
+	return ctx, authKeeper
+}
+
+func getFakeAppAccountParams() (
+	privateKey crypto.PrivKey, publicKey crypto.PubKey, address sdk.AccAddress,
+	coins sdk.Coins, earnedCoins EarnedCoins,
+) {
+	privateKey, publicKey, address = getFakeKeyPubAddr()
+	coins = getFakeCoins()
+	earnedCoins = getFakeEarnedCoins()
+
+	return
+}
+
+func getFakeCoins() sdk.Coins {
+	return sdk.Coins{
+		sdk.NewInt64Coin("fake", 10000000),
+	}
+}
+
+func getFakeEarnedCoins() EarnedCoins {
+	return EarnedCoins{
+		EarnedCoin{
+			sdk.NewInt64Coin("fake", 10000000),
+			uint64(1), // CommunityID
+		},
+	}
+}
+
+func getFakeKeyPubAddr() (crypto.PrivKey, crypto.PubKey, sdk.AccAddress) {
+	key := secp256k1.GenPrivKey()
+	pub := key.PubKey()
+	addr := sdk.AccAddress(pub.Address())
+	return key, pub, addr
+}

--- a/x/auth/errors.go
+++ b/x/auth/errors.go
@@ -1,0 +1,19 @@
+package auth
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Auth errors reserve 200 ~ 299.
+const (
+	DefaultCodespace sdk.CodespaceType = ModuleName
+
+	ErrorCodeAppAccountNotFound sdk.CodeType = 201
+)
+
+// ErrAppAccountNotFound throws an error when the searched AppAccount is not found
+func ErrAppAccountNotFound(address sdk.AccAddress) sdk.Error {
+	return sdk.NewError(DefaultCodespace, ErrorCodeAppAccountNotFound, fmt.Sprintf("AppAccount not found with Address: %s", address))
+}

--- a/x/auth/expected_keepers.go
+++ b/x/auth/expected_keepers.go
@@ -1,0 +1,10 @@
+package auth
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// BankKeeper is the expected bank keeper interface for this module
+type BankKeeper interface {
+	NewTransaction(ctx sdk.Context, to sdk.AccAddress, coins sdk.Coins) bool
+}

--- a/x/auth/genesis.go
+++ b/x/auth/genesis.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// GenesisState defines genesis data for the module
+type GenesisState struct {
+	Params Params `json:"params"`
+}
+
+// NewGenesisState creates a new genesis state.
+func NewGenesisState() GenesisState {
+	return GenesisState{
+		Params: DefaultParams(),
+	}
+}
+
+// DefaultGenesisState returns a default genesis state
+func DefaultGenesisState() GenesisState { return NewGenesisState() }
+
+// InitGenesis initializes story state from genesis file
+func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
+	keeper.SetParams(ctx, data.Params)
+}
+
+// ExportGenesis exports the genesis state
+func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
+	return GenesisState{
+		Params: keeper.GetParams(ctx),
+	}
+}
+
+// ValidateGenesis validates the genesis state data
+func ValidateGenesis(data GenesisState) error {
+	if len(data.Params.Registrar) == 0 {
+		return fmt.Errorf("Param: Registrar, must be a valid address")
+	}
+
+	if data.Params.MaxSlashCount < 1 {
+		return fmt.Errorf("Param: MaxSlashCount, must have a positive value")
+	}
+
+	return nil
+}

--- a/x/auth/handler.go
+++ b/x/auth/handler.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// NewHandler creates a new handler for auth module
+func NewHandler(keeper Keeper) sdk.Handler {
+	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+		switch msg := msg.(type) {
+		case MsgRegisterKey:
+			return handleMsgRegisterKey(ctx, keeper, msg)
+		default:
+			errMsg := fmt.Sprintf("Unrecognized auth message type: %T", msg)
+			return sdk.ErrUnknownRequest(errMsg).Result()
+		}
+	}
+}
+
+func handleMsgRegisterKey(ctx sdk.Context, k Keeper, msg MsgRegisterKey) sdk.Result {
+	if err := msg.ValidateBasic(); err != nil {
+		return err.Result()
+	}
+
+	appAccount := k.NewAppAccount(ctx, msg.Address, msg.Coins, msg.PubKey)
+
+	res, jsonErr := k.codec.MarshalJSON(appAccount)
+	if jsonErr != nil {
+		return sdk.ErrInternal(fmt.Sprintf("Marshal result error: %s", jsonErr)).Result()
+	}
+
+	return sdk.Result{
+		Data: res,
+	}
+}

--- a/x/auth/handler_test.go
+++ b/x/auth/handler_test.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleMsgRegisterKey(t *testing.T) {
+	ctx, keeper := mockDB()
+	handler := NewHandler(keeper)
+	assert.NotNil(t, handler) // assert handler is present
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+	
+	registrar := keeper.GetParams(ctx).Registrar
+
+	msg := NewMsgRegisterKey(registrar, address, publicKey, "secp256k1", coins)
+	assert.NotNil(t, msg) // assert msgs can be created
+
+	result := handler(ctx, msg)
+	var appAccount AppAccount
+	err := keeper.codec.UnmarshalJSON(result.Data, &appAccount)
+	assert.NoError(t, err)
+	t.Log(appAccount)
+	assert.Equal(t, appAccount.PubKey, publicKey)
+}
+
+func TestByzantineMsg(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	handler := NewHandler(keeper)
+	assert.NotNil(t, handler)
+
+	res := handler(ctx, nil)
+	assert.Equal(t, sdk.CodeUnknownRequest, res.Code)
+	assert.Equal(t, sdk.CodespaceRoot, res.Codespace)
+}

--- a/x/auth/keeper.go
+++ b/x/auth/keeper.go
@@ -1,0 +1,161 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkAuth "github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/shanev/cosmos-record-keeper/recordkeeper"
+	"github.com/tendermint/tendermint/crypto"
+	log "github.com/tendermint/tendermint/libs/log"
+)
+
+// Keeper data type storing keys to the KVStore
+type Keeper struct {
+	recordkeeper.RecordKeeper
+
+	codec      *codec.Codec
+	paramStore params.Subspace
+
+	bankKeeper    BankKeeper
+	accountKeeper sdkAuth.AccountKeeper
+}
+
+// NewKeeper creates a new keeper of the auth Keeper
+func NewKeeper(storeKey sdk.StoreKey, paramStore params.Subspace, codec *codec.Codec, bankKeeper BankKeeper, accountKeeper sdkAuth.AccountKeeper) Keeper {
+	return Keeper{
+		recordkeeper.NewRecordKeeper(storeKey, codec),
+		codec,
+		paramStore.WithKeyTable(ParamKeyTable()),
+		bankKeeper,
+		accountKeeper,
+	}
+}
+
+// NewAppAccount creates a new account for a user
+func (k Keeper) NewAppAccount(
+	ctx sdk.Context,
+	address sdk.AccAddress, coins sdk.Coins, pubKey crypto.PubKey,
+) AppAccount {
+
+	logger := getLogger(ctx)
+
+	baseAccount := k.accountKeeper.NewAccountWithAddress(ctx, address)
+
+	appAccount := AppAccount{
+		BaseAccount: sdkAuth.BaseAccount{
+			Address:       address,
+			Coins:         coins,
+			PubKey:        pubKey,
+			AccountNumber: baseAccount.GetAccountNumber(),
+			Sequence:      baseAccount.GetSequence(),
+		},
+
+		EarnedStake: EarnedCoins{},
+		SlashCount:  0,
+		IsJailed:    false,
+		JailEndTime: time.Time{}, // zero value of time.Time; to check, use JailEndTime.IsZero()
+		CreatedTime: ctx.BlockHeader().Time,
+	}
+
+	k.StringSet(ctx, address.String(), appAccount)
+	logger.Info(fmt.Sprintf("Created new appAccount: %s", appAccount.String()))
+
+	k.bankKeeper.NewTransaction(ctx, address, coins)
+
+	return appAccount
+}
+
+// AppAccount returns a AppAccount by its address
+func (k Keeper) AppAccount(ctx sdk.Context, address sdk.AccAddress) (appAccount AppAccount, err sdk.Error) {
+	k.StringGet(ctx, address.String(), &appAccount)
+	if appAccount.BaseAccount.Address.Empty() {
+		return appAccount, ErrAppAccountNotFound(address)
+	}
+
+	return appAccount, nil
+}
+
+// AppAccounts gets all AppAccounts from the KVStore
+func (k Keeper) AppAccounts(ctx sdk.Context) (appAccounts []AppAccount) {
+	err := k.Each(ctx, func(bytes []byte) bool {
+		var appAccount AppAccount
+		k.codec.MustUnmarshalBinaryLengthPrefixed(bytes, &appAccount)
+		appAccounts = append(appAccounts, appAccount)
+		return true
+	})
+
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// AddToEarnedStake adds an EarnedCoin to the EarnedStake
+func (k Keeper) AddToEarnedStake(ctx sdk.Context, address sdk.AccAddress, earnedCoin EarnedCoin) sdk.Error {
+	appAccount, err := k.AppAccount(ctx, address)
+	if err != nil {
+		return err
+	}
+
+	added := false
+	for i, current := range appAccount.EarnedStake {
+		if current.CommunityID == earnedCoin.CommunityID {
+			appAccount.EarnedStake[i].Coin = current.Add(earnedCoin.Coin)
+			added = true
+		}
+	}
+
+	if !added {
+		appAccount.EarnedStake = append(appAccount.EarnedStake, earnedCoin)
+	}
+
+	k.StringSet(ctx, address.String(), appAccount)
+
+	return nil
+}
+
+// JailUntil puts an AppAccount in jail until a time
+func (k Keeper) JailUntil(ctx sdk.Context, address sdk.AccAddress, until time.Time) sdk.Error {
+	appAccount, err := k.AppAccount(ctx, address)
+	if err != nil {
+		return err
+	}
+
+	appAccount.IsJailed = true
+	appAccount.JailEndTime = until
+	k.StringSet(ctx, address.String(), appAccount)
+
+	return nil
+}
+
+// IsJailed tells whether an AppAccount is jailed by its address
+func (k Keeper) IsJailed(ctx sdk.Context, address sdk.AccAddress) (bool, sdk.Error) {
+	appAccount, err := k.AppAccount(ctx, address)
+	if err != nil {
+		return false, err
+	}
+
+	return appAccount.IsJailed, nil
+}
+
+// IncrementSlashCount increments the slash count of the user
+func (k Keeper) IncrementSlashCount(ctx sdk.Context, address sdk.AccAddress) sdk.Error {
+	appAccount, err := k.AppAccount(ctx, address)
+	if err != nil {
+		return err
+	}
+
+	appAccount.SlashCount++
+	k.StringSet(ctx, address.String(), appAccount)
+
+	return nil
+}
+
+func getLogger(ctx sdk.Context) log.Logger {
+	return ctx.Logger().With("module", ModuleName)
+}

--- a/x/auth/keeper_test.go
+++ b/x/auth/keeper_test.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAppAccount_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+
+	appAccount := keeper.NewAppAccount(ctx, address, coins, publicKey)
+
+	assert.Equal(t, appAccount.Address, address)
+	assert.Equal(t, appAccount.Coins, coins)
+	assert.Equal(t, appAccount.PubKey, publicKey)
+}
+
+func TestAppAccount_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+
+	createdAppAccount := keeper.NewAppAccount(ctx, address, coins, publicKey)
+
+	returnedAppAccount, err := keeper.AppAccount(ctx, createdAppAccount.BaseAccount.Address)
+	assert.Nil(t, err)
+	assert.Equal(t, returnedAppAccount.BaseAccount, createdAppAccount.BaseAccount)
+}
+
+func TestAppAccounts_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+	_ = keeper.NewAppAccount(ctx, address, coins, publicKey)
+
+	_, publicKey2, address2, coins2, _ := getFakeAppAccountParams()
+	_ = keeper.NewAppAccount(ctx, address2, coins2, publicKey2)
+
+	all := keeper.AppAccounts(ctx)
+	assert.Len(t, all, 2)
+}
+
+func TestJailUntil_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+
+	createdAppAccount := keeper.NewAppAccount(ctx, address, coins, publicKey)
+	isJailed, err := keeper.IsJailed(ctx, createdAppAccount.BaseAccount.Address)
+	assert.Nil(t, err)
+	assert.Equal(t, false, isJailed)
+
+	keeper.JailUntil(ctx, createdAppAccount.BaseAccount.Address, time.Now().AddDate(0, 0, 10))
+	isJailed, err = keeper.IsJailed(ctx, createdAppAccount.BaseAccount.Address)
+	assert.Nil(t, err)
+	assert.Equal(t, true, isJailed)
+}
+
+func TestAddToEarnedStake_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+
+	createdAppAccount := keeper.NewAppAccount(ctx, address, coins, publicKey)
+	assert.Len(t, createdAppAccount.EarnedStake, 0)
+
+	earnedCoin := EarnedCoin{sdk.NewCoin("testcoin", sdk.NewInt(10)), uint64(1)}
+
+	// adding for the first time
+	keeper.AddToEarnedStake(ctx, createdAppAccount.Address, earnedCoin)
+	returnedAppAccount, err := keeper.AppAccount(ctx, createdAppAccount.Address)
+	assert.Nil(t, err)
+	assert.Len(t, returnedAppAccount.EarnedStake, 1)
+	assert.Equal(t, returnedAppAccount.EarnedStake[0], earnedCoin)
+
+	// adding again
+	keeper.AddToEarnedStake(ctx, createdAppAccount.Address, earnedCoin)
+	returnedAppAccount, err = keeper.AppAccount(ctx, createdAppAccount.Address)
+	assert.Nil(t, err)
+	assert.Len(t, returnedAppAccount.EarnedStake, 1)
+	assert.Equal(t, returnedAppAccount.EarnedStake[0].Coin, earnedCoin.Add(earnedCoin.Coin))
+}
+
+func TestIncrementSlashCount_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+
+	createdAppAccount := keeper.NewAppAccount(ctx, address, coins, publicKey)
+	assert.Equal(t, createdAppAccount.SlashCount, uint(0))
+
+	// incrementing once
+	keeper.IncrementSlashCount(ctx, createdAppAccount.Address)
+	returnedAppAccount, err := keeper.AppAccount(ctx, createdAppAccount.Address)
+	assert.Nil(t, err)
+	assert.Equal(t, returnedAppAccount.SlashCount, uint(1))
+
+	// incrementing again
+	keeper.IncrementSlashCount(ctx, createdAppAccount.Address)
+	returnedAppAccount, err = keeper.AppAccount(ctx, createdAppAccount.Address)
+	assert.Nil(t, err)
+	assert.Equal(t, returnedAppAccount.SlashCount, uint(2))
+}

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -1,0 +1,102 @@
+package auth
+
+import (
+	"encoding/json"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+var (
+	_ sdk.AppModule      = AppModule{}
+	_ sdk.AppModuleBasic = AppModuleBasic{}
+)
+
+// ModuleName is the name of this module
+const ModuleName = "truchain_auth"
+
+// AppModuleBasic defines the internal data for the module
+// ----------------------------------------------------------------------------
+type AppModuleBasic struct{}
+
+var _ sdk.AppModuleBasic = AppModuleBasic{}
+
+// Name define the name of the module
+func (AppModuleBasic) Name() string {
+	return ModuleName
+}
+
+// RegisterCodec registers the types needed for amino encoding/decoding
+func (AppModuleBasic) RegisterCodec(cdc *codec.Codec) {
+	RegisterCodec(cdc)
+}
+
+// DefaultGenesis creates the default genesis state for testing
+func (AppModuleBasic) DefaultGenesis() json.RawMessage {
+	return ModuleCodec.MustMarshalJSON(DefaultGenesisState())
+}
+
+// ValidateGenesis validates the genesis state
+func (AppModuleBasic) ValidateGenesis(bz json.RawMessage) error {
+	var data GenesisState
+	err := ModuleCodec.UnmarshalJSON(bz, &data)
+	if err != nil {
+		return err
+	}
+	return ValidateGenesis(data)
+}
+
+// AppModule defines external data for the module
+// ----------------------------------------------------------------------------
+type AppModule struct {
+	AppModuleBasic
+	keeper Keeper
+}
+
+// RegisterInvariants enforces registering of invariants
+func (AppModule) RegisterInvariants(_ sdk.InvariantRouter) {}
+
+// Route defines the key for the route
+func (AppModule) Route() string {
+	return RouterKey
+}
+
+// NewHandler creates the handler for the auth module
+func (am AppModule) NewHandler() sdk.Handler {
+	return NewHandler(am.keeper)
+}
+
+// QuerierRoute defines the querier route
+func (AppModule) QuerierRoute() string {
+	return QuerierRoute
+}
+
+// NewQuerierHandler creates a new querier handler
+func (am AppModule) NewQuerierHandler() sdk.Querier {
+	return NewQuerier(am.keeper)
+}
+
+// InitGenesis enforces the creation of the genesis state for the auth module
+func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
+	var genesisState GenesisState
+	ModuleCodec.MustUnmarshalJSON(data, &genesisState)
+	InitGenesis(ctx, am.keeper, genesisState)
+	return []abci.ValidatorUpdate{}
+}
+
+// ExportGenesis enforces exporting this module's data to a genesis file
+func (am AppModule) ExportGenesis(ctx sdk.Context) json.RawMessage {
+	gs := ExportGenesis(ctx, am.keeper)
+	return ModuleCodec.MustMarshalJSON(gs)
+}
+
+// BeginBlock runs before a block is processed
+func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) sdk.Tags {
+	return sdk.EmptyTags()
+}
+
+// EndBlock runs at the end of each block
+func (AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) ([]abci.ValidatorUpdate, sdk.Tags) {
+	return []abci.ValidatorUpdate{}, sdk.EmptyTags()
+}

--- a/x/auth/msgs.go
+++ b/x/auth/msgs.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/crypto"
+)
+
+const (
+	// TypeMsgRegisterKey represents the type of the message for registering the key
+	TypeMsgRegisterKey = "register_key"
+)
+
+// MsgRegisterKey defines the message to register a new key
+type MsgRegisterKey struct {
+	Registrar  sdk.AccAddress `json:"registrar"`
+	Address    sdk.AccAddress `json:"address"`
+	PubKey     crypto.PubKey  `json:"public_key"`
+	PubKeyAlgo string         `json:"public_key_algo"`
+	Coins      sdk.Coins      `json:"coins"`
+}
+
+// NewMsgRegisterKey returns the messages to register a new key
+func NewMsgRegisterKey(registrar, address sdk.AccAddress, publicKey crypto.PubKey, publicKeyAlgo string, coins sdk.Coins) MsgRegisterKey {
+	return MsgRegisterKey{
+		Registrar:  registrar,
+		Address:    address,
+		PubKey:     publicKey,
+		PubKeyAlgo: publicKeyAlgo,
+		Coins:      coins,
+	}
+}
+
+// ValidateBasic implements Msg
+func (msg MsgRegisterKey) ValidateBasic() sdk.Error {
+	if len(msg.Registrar) == 0 {
+		return sdk.ErrInvalidAddress(fmt.Sprintf("Invalid registrar: %s", msg.Registrar.String()))
+	}
+
+	if len(msg.Address) == 0 {
+		return sdk.ErrInvalidAddress(fmt.Sprintf("Invalid address: %s", msg.Address.String()))
+	}
+
+	return nil
+}
+
+// Route implements Msg
+func (msg MsgRegisterKey) Route() string { return RouterKey }
+
+// Type implements Msg
+func (msg MsgRegisterKey) Type() string { return TypeMsgRegisterKey }
+
+// GetSignBytes implements Msg
+func (msg MsgRegisterKey) GetSignBytes() []byte {
+	msgBytes := ModuleCodec.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(msgBytes)
+}
+
+// GetSigners implements Msg. Returns the registrar as the signer.
+func (msg MsgRegisterKey) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Registrar}
+}

--- a/x/auth/msgs_test.go
+++ b/x/auth/msgs_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMsgRegisterKey_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+
+	registrar := keeper.GetParams(ctx).Registrar
+
+	msg := NewMsgRegisterKey(registrar, address, publicKey, "secp256k1", coins)
+	err := msg.ValidateBasic()
+	assert.Nil(t, err)
+	assert.Equal(t, ModuleName, msg.Route())
+	assert.Equal(t, TypeMsgRegisterKey, msg.Type())
+}
+
+func TestMsgNewCommunity_InvalidAddress(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, _, coins, _ := getFakeAppAccountParams()
+	invalidAddress := sdk.AccAddress(nil)
+
+	registrar := keeper.GetParams(ctx).Registrar
+
+	msg := NewMsgRegisterKey(registrar, invalidAddress, publicKey, "secp256k1", coins)
+	err := msg.ValidateBasic()
+	assert.NotNil(t, err)
+	assert.Equal(t, sdk.ErrInvalidAddress("").Code(), err.Code())
+}

--- a/x/auth/params.go
+++ b/x/auth/params.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+)
+
+// Keys for params
+var (
+	KeyRegistrar     = []byte("registrar")
+	KeyMaxSlashCount = []byte("maxSlashCount")
+)
+
+// Params holds parameters for Auth
+type Params struct {
+	Registrar     sdk.AccAddress `json:"registrar"`
+	MaxSlashCount int            `json:"max_slash_count"`
+}
+
+// DefaultParams is the auth params for testing
+func DefaultParams() Params {
+	return Params{
+		Registrar: nil,
+		MaxSlashCount: 50,
+	}
+}
+
+// ParamSetPairs implements params.ParamSet
+func (p *Params) ParamSetPairs() params.ParamSetPairs {
+	return params.ParamSetPairs{
+		{Key: KeyRegistrar, Value: &p.Registrar},
+		{Key: KeyMaxSlashCount, Value: &p.MaxSlashCount},
+	}
+}
+
+// ParamKeyTable for auth module
+func ParamKeyTable() params.KeyTable {
+	return params.NewKeyTable().RegisterParamSet(&Params{})
+}
+
+// GetParams gets the genesis params for the auth
+func (k Keeper) GetParams(ctx sdk.Context) Params {
+	var paramSet Params
+	k.paramStore.GetParamSet(ctx, &paramSet)
+	return paramSet
+}
+
+// SetParams sets the params for the auth
+func (k Keeper) SetParams(ctx sdk.Context, params Params) {
+	logger := ctx.Logger().With("module", ModuleName)
+	k.paramStore.SetParamSet(ctx, &params)
+	logger.Info(fmt.Sprintf("Loaded auth params: %+v", params))
+}

--- a/x/auth/querier.go
+++ b/x/auth/querier.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// query endpoints supported by the truchain Querier
+const (
+	QueryAppAccount  = "account"
+	QueryAppAccounts = "accounts"
+)
+
+// QueryAppAccountParams are params for querying app accounts by address queries
+type QueryAppAccountParams struct {
+	Address sdk.AccAddress
+}
+
+// NewQuerier creates a new querier
+func NewQuerier(keeper Keeper) sdk.Querier {
+	return func(ctx sdk.Context, path []string, request abci.RequestQuery) ([]byte, sdk.Error) {
+		switch path[0] {
+		case QueryAppAccount:
+			return queryAppAccount(ctx, request, keeper)
+		case QueryAppAccounts:
+			return queryAppAccounts(ctx, keeper)
+		default:
+			return nil, sdk.ErrUnknownRequest(fmt.Sprintf("Unknown truchain query endpoint: auth/%s", path[0]))
+		}
+	}
+}
+
+func queryAppAccount(ctx sdk.Context, request abci.RequestQuery, k Keeper) (result []byte, err sdk.Error) {
+	params := QueryAppAccountParams{}
+	if err = unmarshalQueryParams(request, &params); err != nil {
+		return
+	}
+
+	appAccount, err := k.AppAccount(ctx, params.Address)
+	if err != nil {
+		return
+	}
+
+	result, jsonErr := k.codec.MarshalJSON(appAccount)
+	if jsonErr != nil {
+		panic(jsonErr)
+	}
+	return result, nil
+}
+
+func queryAppAccounts(ctx sdk.Context, k Keeper) (result []byte, err sdk.Error) {
+	appAccounts := k.AppAccounts(ctx)
+
+	result, jsonErr := k.codec.MarshalJSON(appAccounts)
+	if jsonErr != nil {
+		panic(jsonErr)
+	}
+	return result, nil
+}
+
+func unmarshalQueryParams(request abci.RequestQuery, params interface{}) (sdkErr sdk.Error) {
+	err := json.Unmarshal(request.Data, params)
+	if err != nil {
+		sdkErr = sdk.ErrUnknownRequest(fmt.Sprintf("Incorrectly formatted request data - %s", err.Error()))
+		return
+	}
+	return
+}

--- a/x/auth/querier_test.go
+++ b/x/auth/querier_test.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func TestQueryAppAccount_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+	createdAppAccount := keeper.NewAppAccount(ctx, address, coins, publicKey)
+
+	params, jsonErr := json.Marshal(QueryAppAccountParams{
+		Address: address,
+	})
+	assert.Nil(t, jsonErr)
+
+	query := abci.RequestQuery{
+		Path: fmt.Sprintf("/custom/%s/%s", ModuleName, QueryAppAccount),
+		Data: params,
+	}
+
+	result, sdkErr := queryAppAccount(ctx, query, keeper)
+	assert.Nil(t, sdkErr)
+
+	var returnedAppAccount AppAccount
+	jsonErr = keeper.codec.UnmarshalJSON(result, &returnedAppAccount)
+	assert.Nil(t, jsonErr)
+	assert.Equal(t, returnedAppAccount.BaseAccount, createdAppAccount.BaseAccount)
+}
+
+func TestQueryAppAccount_ErrNotFound(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, _, address, _, _ := getFakeAppAccountParams()
+
+	params, jsonErr := json.Marshal(QueryAppAccountParams{
+		Address: address,
+	})
+	assert.Nil(t, jsonErr)
+
+	query := abci.RequestQuery{
+		Path: fmt.Sprintf("/custom/%s/%s", ModuleName, QueryAppAccount),
+		Data: params,
+	}
+
+	_, sdkErr := queryAppAccount(ctx, query, keeper)
+	assert.NotNil(t, sdkErr)
+	t.Log(sdkErr)
+	assert.Equal(t, ErrAppAccountNotFound(address).Code(), sdkErr.Code())
+}
+
+func TestQueryAppAccounts_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins, _ := getFakeAppAccountParams()
+	_ = keeper.NewAppAccount(ctx, address, coins, publicKey)
+
+	_, publicKey2, address2, coins2, _ := getFakeAppAccountParams()
+	_ = keeper.NewAppAccount(ctx, address2, coins2, publicKey2)
+
+	result, sdkErr := queryAppAccounts(ctx, keeper)
+	assert.Nil(t, sdkErr)
+
+	var appAccounts []AppAccount
+	jsonErr := keeper.codec.UnmarshalJSON(result, &appAccounts)
+	assert.Nil(t, jsonErr)
+	assert.Len(t, appAccounts, 2)
+}

--- a/x/auth/types.go
+++ b/x/auth/types.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkAuth "github.com/cosmos/cosmos-sdk/x/auth"
+)
+
+// Defines auth module constants
+const (
+	RouterKey    = ModuleName
+	QuerierRoute = ModuleName
+)
+
+// EarnedCoin is a representation of a coin associated with a community, or "earned trustake".
+type EarnedCoin struct {
+	sdk.Coin
+
+	CommunityID uint64
+}
+
+// EarnedCoins is a collection of EarnedCoins
+type EarnedCoins []EarnedCoin
+
+// AppAccount is the main account for a TruStory user.
+type AppAccount struct {
+	sdkAuth.BaseAccount
+
+	EarnedStake EarnedCoins
+	SlashCount  uint
+	IsJailed    bool
+	JailEndTime time.Time
+	CreatedTime time.Time
+}
+
+func (appAccount AppAccount) String() string {
+	return fmt.Sprintf("AppAccount <%s %s>", appAccount.BaseAccount.Address, appAccount.BaseAccount.PubKey)
+}

--- a/x/community/msgs.go
+++ b/x/community/msgs.go
@@ -3,11 +3,11 @@ package community
 import (
 	"fmt"
 
-	app "github.com/TruStory/truchain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
+	// TypeMsgNewCommunity represents the type of the message for creating new community
 	TypeMsgNewCommunity = "new_community"
 )
 
@@ -46,10 +46,11 @@ func (msg MsgNewCommunity) Type() string { return TypeMsgNewCommunity }
 
 // GetSignBytes implements Msg
 func (msg MsgNewCommunity) GetSignBytes() []byte {
-	return app.MustGetSignBytes(msg)
+	msgBytes := ModuleCodec.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(msgBytes)
 }
 
 // GetSigners implements Msg. Returns the creator as the signer.
 func (msg MsgNewCommunity) GetSigners() []sdk.AccAddress {
-	return app.GetSigners(msg.Creator)
+	return []sdk.AccAddress{sdk.AccAddress(msg.Creator)}
 }


### PR DESCRIPTION
### Summary
New auth module takes care of registering new users and managing their jailed status.

### Note
The implementation might see some changes due to the following:
1. The actual implementation of the new Bank module might affect the expected keeper.
2. This PR uses Amino encoding/decoding. Might be changed after finalizing what to use after the Engineering catchup after @shanev's return from his trip.
3. This PR has a pending issue: migrating old accounts to the new auth module. (I will have to spend some time understanding the python script. Will add it on the weekend after wrapping up currently-in-progress Slashing module.)