### PR TITLE
Send raw public key bytes in register msg

### DIFF
--- a/x/account/handler_test.go
+++ b/x/account/handler_test.go
@@ -17,7 +17,7 @@ func TestHandleMsgRegisterKey(t *testing.T) {
 
 	registrar := keeper.GetParams(ctx).Registrar
 
-	msg := NewMsgRegisterKey(registrar, address, publicKey, "secp256k1", coins)
+	msg := NewMsgRegisterKey(registrar, address, publicKey.Bytes(), "secp256k1", coins)
 	assert.NotNil(t, msg) // assert msgs can be created
 
 	result := handler(ctx, msg)
@@ -25,7 +25,8 @@ func TestHandleMsgRegisterKey(t *testing.T) {
 	err := keeper.codec.UnmarshalJSON(result.Data, &appAccount)
 	assert.NoError(t, err)
 	t.Log(appAccount)
-	assert.Equal(t, appAccount.PubKey, publicKey)
+	convertedPubKey, _ := toPubKey("secp256k1", publicKey.Bytes())
+	assert.Equal(t, appAccount.PubKey, convertedPubKey)
 }
 
 func TestByzantineMsg(t *testing.T) {

--- a/x/account/msgs.go
+++ b/x/account/msgs.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/tendermint/tendermint/crypto"
+	tcmn "github.com/tendermint/tendermint/libs/common"
 )
 
 const (
@@ -17,13 +17,13 @@ const (
 type MsgRegisterKey struct {
 	Registrar  sdk.AccAddress `json:"registrar"`
 	Address    sdk.AccAddress `json:"address"`
-	PubKey     crypto.PubKey  `json:"public_key"`
+	PubKey     tcmn.HexBytes  `json:"public_key"`
 	PubKeyAlgo string         `json:"public_key_algo"`
 	Coins      sdk.Coins      `json:"coins"`
 }
 
 // NewMsgRegisterKey returns the messages to register a new key
-func NewMsgRegisterKey(registrar, address sdk.AccAddress, publicKey crypto.PubKey, publicKeyAlgo string, coins sdk.Coins) MsgRegisterKey {
+func NewMsgRegisterKey(registrar, address sdk.AccAddress, publicKey tcmn.HexBytes, publicKeyAlgo string, coins sdk.Coins) MsgRegisterKey {
 	return MsgRegisterKey{
 		Registrar:  registrar,
 		Address:    address,

--- a/x/account/msgs_test.go
+++ b/x/account/msgs_test.go
@@ -15,7 +15,7 @@ func TestMsgRegisterKey_Success(t *testing.T) {
 
 	registrar := keeper.GetParams(ctx).Registrar
 
-	msg := NewMsgRegisterKey(registrar, address, publicKey, "secp256k1", coins)
+	msg := NewMsgRegisterKey(registrar, address, publicKey.Bytes(), "secp256k1", coins)
 	err := msg.ValidateBasic()
 	assert.Nil(t, err)
 	assert.Equal(t, ModuleName, msg.Route())
@@ -30,7 +30,7 @@ func TestMsgNewCommunity_InvalidAddress(t *testing.T) {
 
 	registrar := keeper.GetParams(ctx).Registrar
 
-	msg := NewMsgRegisterKey(registrar, invalidAddress, publicKey, "secp256k1", coins)
+	msg := NewMsgRegisterKey(registrar, invalidAddress, publicKey.Bytes(), "secp256k1", coins)
 	err := msg.ValidateBasic()
 	assert.NotNil(t, err)
 	assert.Equal(t, sdk.ErrInvalidAddress("").Code(), err.Code())


### PR DESCRIPTION
Passing in a byte array in in the register message because Thunder GraphQL doesn't have a way to handle Go interfaces yet (since `crypto.PubKey` is an interface).