### PR TITLE
Added accounts by addresses query

### DIFF
--- a/x/account/querier_test.go
+++ b/x/account/querier_test.go
@@ -3,8 +3,11 @@ package account
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
@@ -31,7 +34,45 @@ func TestQueryAppAccount_Success(t *testing.T) {
 	var returnedAppAccount AppAccount
 	jsonErr = keeper.codec.UnmarshalJSON(result, &returnedAppAccount)
 	assert.Nil(t, jsonErr)
-	assert.Equal(t, returnedAppAccount.BaseAccount, createdAppAccount.BaseAccount)
+	assert.Equal(t, returnedAppAccount.GetAddress(), createdAppAccount.GetAddress())
+}
+
+func TestQueryAppAccounts_Success(t *testing.T) {
+	ctx, keeper := mockDB()
+
+	_, publicKey, address, coins := getFakeAppAccountParams()
+	createdAppAccount, err := keeper.CreateAppAccount(ctx, address, coins, publicKey)
+	assert.NoError(t, err)
+
+	_, publicKey2, address2, coins2 := getFakeAppAccountParams()
+	_, err = keeper.CreateAppAccount(ctx, address2, coins2, publicKey2)
+	assert.NoError(t, err)
+
+	_, publicKey3, address3, coins3 := getFakeAppAccountParams()
+	_, err = keeper.CreateAppAccount(ctx, address3, coins3, publicKey3)
+	assert.NoError(t, err)
+
+	queryParams := QueryAppAccountsParams{
+		Addresses: []sdk.AccAddress{address, address2, address3},
+	}
+	queryParamsBytes, jsonErr := ModuleCodec.MarshalJSON(queryParams)
+	assert.NoError(t, jsonErr)
+
+	query := abci.RequestQuery{
+		Path: strings.Join([]string{"custom", QueryAppAccounts}, "/"),
+		Data: queryParamsBytes,
+	}
+
+	querier := NewQuerier(keeper)
+	resBytes, err := querier(ctx, []string{QueryAppAccounts}, query)
+	require.NoError(t, err)
+
+	returnedAppAccounts := make([]AppAccount, 0, len(queryParams.Addresses))
+
+	jsonErr = ModuleCodec.UnmarshalJSON(resBytes, &returnedAppAccounts)
+	assert.NoError(t, jsonErr)
+	assert.Equal(t, returnedAppAccounts[0].GetAddress(), createdAppAccount.GetAddress())
+	assert.Len(t, returnedAppAccounts, 3)
 }
 
 func TestQueryAppAccount_ErrNotFound(t *testing.T) {

--- a/x/account/types.go
+++ b/x/account/types.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/x/auth"
@@ -24,6 +25,16 @@ type AppAccount struct {
 	IsJailed    bool      `json:"is_jailed"`
 	JailEndTime time.Time `json:"jail_end_time"`
 	CreatedTime time.Time `json:"created_time"`
+}
+
+// String implements fmt.Stringer
+func (acc AppAccount) String() string {
+	return fmt.Sprintf(`%s
+  SlashCount:        %d
+  IsJailed:          %t
+  JailEndTime:       %s
+  CreatedTime:       %s`,
+		acc.BaseAccount.String(), acc.SlashCount, acc.IsJailed, acc.JailEndTime.String(), acc.CreatedTime.String())
 }
 
 // AppAccounts is a slice of AppAccounts


### PR DESCRIPTION
In the old user by addresses query, we passed account addresses as strings instead of `sdk.AccAddress`. We can do this conversion in the API layer. Let me know if that's an issue. 

https://godoc.org/github.com/cosmos/cosmos-sdk/types#AccAddressFromBech32