### PR TITLE
Added new module params to params keeper

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -291,6 +291,11 @@ func NewTruChain(logger log.Logger, db dbm.DB, loadLatest bool, options ...func(
 		app.expirationKeeper,
 		app.stakeKeeper,
 		app.storyKeeper,
+		app.appAccountKeeper,
+		app.communityKeeper,
+		app.claimKeeper,
+		app.truBankKeeper2,
+		app.truStakingKeeper,
 	)
 
 	app.communityKeeper = community.NewKeeper(

--- a/x/params/keeper.go
+++ b/x/params/keeper.go
@@ -1,11 +1,16 @@
 package params
 
 import (
+	"github.com/TruStory/truchain/x/account"
 	"github.com/TruStory/truchain/x/argument"
 	"github.com/TruStory/truchain/x/backing"
+	"github.com/TruStory/truchain/x/bank"
 	"github.com/TruStory/truchain/x/challenge"
+	"github.com/TruStory/truchain/x/claim"
+	"github.com/TruStory/truchain/x/community"
 	"github.com/TruStory/truchain/x/expiration"
 	"github.com/TruStory/truchain/x/stake"
+	"github.com/TruStory/truchain/x/staking"
 	"github.com/TruStory/truchain/x/story"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -23,6 +28,11 @@ type Keeper struct {
 	expirationKeeper expiration.Keeper
 	stakeKeeper      stake.Keeper
 	storyKeeper      story.ReadKeeper
+	accountKeeper    account.Keeper
+	communityKeeper  community.Keeper
+	claimKeeper      claim.Keeper
+	bankKeeper       bank.Keeper
+	stakingKeeper    staking.Keeper
 }
 
 // NewKeeper creates a new keeper with write and read access
@@ -32,7 +42,12 @@ func NewKeeper(
 	challengeKeeper challenge.WriteKeeper,
 	expirationKeeper expiration.Keeper,
 	stakeKeeper stake.Keeper,
-	storyKeeper story.WriteKeeper) Keeper {
+	storyKeeper story.WriteKeeper,
+	accountKeeper account.Keeper,
+	communityKeeper community.Keeper,
+	claimKeeper claim.Keeper,
+	bankKeeper bank.Keeper,
+	stakingKeeper staking.Keeper) Keeper {
 
 	return Keeper{
 		argumentKeeper,
@@ -41,6 +56,11 @@ func NewKeeper(
 		expirationKeeper,
 		stakeKeeper,
 		storyKeeper,
+		accountKeeper,
+		communityKeeper,
+		claimKeeper,
+		bankKeeper,
+		stakingKeeper,
 	}
 }
 
@@ -64,6 +84,39 @@ func (k Keeper) Params(ctx sdk.Context) Params {
 			ExpireDuration: k.storyKeeper.GetParams(ctx).ExpireDuration,
 			MinStoryLength: k.storyKeeper.GetParams(ctx).MinStoryLength,
 			MaxStoryLength: k.storyKeeper.GetParams(ctx).MaxStoryLength,
+		},
+		AccountParams: account.Params{
+			Registrar:     k.accountKeeper.GetParams(ctx).Registrar,
+			MaxSlashCount: k.accountKeeper.GetParams(ctx).MaxSlashCount,
+		},
+		CommunityParams: community.Params{
+			MinIDLength:          k.communityKeeper.GetParams(ctx).MinIDLength,
+			MaxIDLength:          k.communityKeeper.GetParams(ctx).MaxIDLength,
+			MinNameLength:        k.communityKeeper.GetParams(ctx).MinNameLength,
+			MaxNameLength:        k.communityKeeper.GetParams(ctx).MaxNameLength,
+			MaxDescriptionLength: k.communityKeeper.GetParams(ctx).MaxDescriptionLength,
+		},
+		ClaimParams: claim.Params{
+			MinClaimLength: k.claimKeeper.GetParams(ctx).MinClaimLength,
+			MaxClaimLength: k.claimKeeper.GetParams(ctx).MaxClaimLength,
+		},
+		BankParams: bank.Params{
+			RewardBrokerAddress: k.bankKeeper.GetParams(ctx).RewardBrokerAddress,
+		},
+		StakingParams: staking.Params{
+			Period:                   k.stakingKeeper.GetParams(ctx).Period,
+			ArgumentCreationStake:    k.stakingKeeper.GetParams(ctx).ArgumentCreationStake,
+			ArgumentBodyMaxLength:    k.stakingKeeper.GetParams(ctx).ArgumentBodyMaxLength,
+			ArgumentBodyMinLength:    k.stakingKeeper.GetParams(ctx).ArgumentBodyMinLength,
+			ArgumentSummaryMaxLength: k.stakingKeeper.GetParams(ctx).ArgumentSummaryMaxLength,
+			ArgumentSummaryMinLength: k.stakingKeeper.GetParams(ctx).ArgumentSummaryMinLength,
+			UpvoteStake:              k.stakingKeeper.GetParams(ctx).UpvoteStake,
+			CreatorShare:             k.stakingKeeper.GetParams(ctx).CreatorShare,
+			InterestRate:             k.stakingKeeper.GetParams(ctx).InterestRate,
+			StakeLimitPercent:        k.stakingKeeper.GetParams(ctx).StakeLimitPercent,
+			StakeLimitDays:           k.stakingKeeper.GetParams(ctx).StakeLimitDays,
+			UnjailUpvotes:            k.stakingKeeper.GetParams(ctx).UnjailUpvotes,
+			MaxArgumentsPerClaim:     k.stakingKeeper.GetParams(ctx).MaxArgumentsPerClaim,
 		},
 	}
 }

--- a/x/params/types.go
+++ b/x/params/types.go
@@ -1,10 +1,15 @@
 package params
 
 import (
+	"github.com/TruStory/truchain/x/account"
 	"github.com/TruStory/truchain/x/argument"
+	"github.com/TruStory/truchain/x/bank"
 	"github.com/TruStory/truchain/x/challenge"
+	"github.com/TruStory/truchain/x/claim"
+	"github.com/TruStory/truchain/x/community"
 	"github.com/TruStory/truchain/x/expiration"
 	"github.com/TruStory/truchain/x/stake"
+	"github.com/TruStory/truchain/x/staking"
 	"github.com/TruStory/truchain/x/story"
 )
 
@@ -19,6 +24,11 @@ type Params struct {
 	ExpirationParams expiration.Params
 	StakeParams      stake.Params
 	StoryParams      story.Params
+	AccountParams    account.Params
+	CommunityParams  community.Params
+	ClaimParams      claim.Params
+	BankParams       bank.Params
+	StakingParams    staking.Params
 }
 
 // DefaultParams creates the default params
@@ -29,5 +39,10 @@ func DefaultParams() Params {
 		ExpirationParams: expiration.DefaultParams(),
 		StakeParams:      stake.DefaultParams(),
 		StoryParams:      story.DefaultParams(),
+		AccountParams:    account.DefaultParams(),
+		CommunityParams:  community.DefaultParams(),
+		ClaimParams:      claim.DefaultParams(),
+		BankParams:       bank.DefaultParams(),
+		StakingParams:    staking.DefaultParams(),
 	}
 }


### PR DESCRIPTION
Fixes #683.

Added new modules for params. Slashing will need to be added after it's done. Let me know if anything is missed. Comment length lives on the client side so that should come from the client/API.
