### PR TITLE
Change StakeType from byte to int8

### DIFF
--- a/x/staking/keeper_test.go
+++ b/x/staking/keeper_test.go
@@ -45,7 +45,7 @@ func TestKeeper_SubmitArgument(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, ErrorCodeInvalidStakeType, err.Code())
 
-	_, err = k.SubmitArgument(ctx, "body", "summary", addr, 1, StakeType(0xFF))
+	_, err = k.SubmitArgument(ctx, "body", "summary", addr, 1, 127)
 	assert.Error(t, err)
 	assert.Equal(t, ErrorCodeInvalidStakeType, err.Code())
 

--- a/x/staking/types.go
+++ b/x/staking/types.go
@@ -16,7 +16,7 @@ const (
 	DefaultParamspace = ModuleName
 )
 
-type StakeType byte
+type StakeType int8
 
 func (t StakeType) String() string {
 	if int(t) >= len(StakeTypeName) {


### PR DESCRIPTION
It would be easier for the client to communicate with the backend if StakeType was changed to int8 from byte because support for int backed enums is more consistent across Typescript and Go. 

Is there any downside or issue with modifying this? 