### PR TITLE
Added community id to transaction, staking, argument

### DIFF
--- a/x/account/common_test.go
+++ b/x/account/common_test.go
@@ -29,7 +29,7 @@ type bankKeeper struct {
 
 // AddCoin mock for bank keeper
 func (bk bankKeeper) AddCoin(ctx sdk.Context, to sdk.AccAddress, coin sdk.Coin,
-	referenceID uint64, txType bank.TransactionType) (sdk.Coins, sdk.Error) {
+	referenceID uint64, txType bank.TransactionType, setters ...bank.TransactionSetter) (sdk.Coins, sdk.Error) {
 
 	txn := transaction{to, coin}
 	bk.Transactions = append(bk.Transactions, txn)

--- a/x/account/expected_keepers.go
+++ b/x/account/expected_keepers.go
@@ -1,12 +1,12 @@
 package account
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankexported "github.com/TruStory/truchain/x/bank/exported"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // BankKeeper is the expected bank keeper interface for this module
 type BankKeeper interface {
 	AddCoin(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin,
-		referenceID uint64, txType bankexported.TransactionType) (sdk.Coins, sdk.Error)
+		referenceID uint64, txType bankexported.TransactionType, setters ...bankexported.TransactionSetter) (sdk.Coins, sdk.Error)
 }

--- a/x/bank/alias.go
+++ b/x/bank/alias.go
@@ -39,6 +39,7 @@ var (
 
 type (
 	TransactionType                  = exported.TransactionType
+	TransactionSetter                = exported.TransactionSetter
 	Filter                           = exported.Filter
 	SortOrderType                    = exported.SortOrderType
 	Transaction                      = exported.Transaction

--- a/x/bank/exported/exported.go
+++ b/x/bank/exported/exported.go
@@ -14,6 +14,7 @@ type Transaction struct {
 	Type              TransactionType `json:"type"`
 	AppAccountAddress sdk.AccAddress  `json:"app_account_address"`
 	ReferenceID       uint64          `json:"reference_id"`
+	CommunityID       string          `json:"community_id"`
 	Amount            sdk.Coin        `json:"amount"`
 	CreatedTime       time.Time       `json:"created_time"`
 }
@@ -89,6 +90,14 @@ func (t TransactionType) OneOf(types []TransactionType) bool {
 		}
 	}
 	return false
+}
+
+type TransactionSetter func(*Transaction)
+
+func WithCommunityID(communityID string) TransactionSetter {
+	return func(tx *Transaction) {
+		tx.CommunityID = communityID
+	}
 }
 
 type SortOrderType int8

--- a/x/bank/keeper.go
+++ b/x/bank/keeper.go
@@ -35,7 +35,11 @@ func (k Keeper) Codespace() sdk.CodespaceType {
 
 // AddCoin adds a coin to an address and adds the transaction to the association list.
 func (k Keeper) AddCoin(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin,
-	referenceID uint64, txType TransactionType) (sdk.Coins, sdk.Error) {
+	referenceID uint64, txType TransactionType, txSetters ...TransactionSetter) (sdk.Coins, sdk.Error) {
+	tx := Transaction{}
+	for _, setter := range txSetters {
+		setter(&tx)
+	}
 	if !txType.AllowedForAddition() {
 		return sdk.Coins{}, ErrInvalidTransactionType(txType)
 	}
@@ -47,14 +51,13 @@ func (k Keeper) AddCoin(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin,
 	if err != nil {
 		return sdk.Coins{}, err
 	}
-	tx := Transaction{
-		ID:                transactionID,
-		Type:              txType,
-		ReferenceID:       referenceID,
-		Amount:            amt,
-		AppAccountAddress: addr,
-		CreatedTime:       ctx.BlockHeader().Time,
-	}
+	tx.ID = transactionID
+	tx.Type = txType
+	tx.ReferenceID = referenceID
+	tx.Amount = amt
+	tx.AppAccountAddress = addr
+	tx.CreatedTime = ctx.BlockHeader().Time
+
 	k.setTransaction(ctx, tx)
 	k.setTransactionID(ctx, transactionID+1)
 	k.setUserTransaction(ctx, addr, tx.CreatedTime, tx.ID)
@@ -63,7 +66,11 @@ func (k Keeper) AddCoin(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin,
 
 // SubtractCoin subtracts a coin from an address and adds the transaction to the association list.
 func (k Keeper) SubtractCoin(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin,
-	referenceID uint64, txType TransactionType) (sdk.Coins, sdk.Error) {
+	referenceID uint64, txType TransactionType, txSetters ...TransactionSetter) (sdk.Coins, sdk.Error) {
+	tx := Transaction{}
+	for _, setter := range txSetters {
+		setter(&tx)
+	}
 	if !txType.AllowedForDeduction() {
 		return sdk.Coins{}, ErrInvalidTransactionType(txType)
 	}
@@ -76,14 +83,14 @@ func (k Keeper) SubtractCoin(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin,
 	if err != nil {
 		return sdk.Coins{}, err
 	}
-	tx := Transaction{
-		ID:                transactionID,
-		Type:              txType,
-		ReferenceID:       referenceID,
-		Amount:            amt,
-		AppAccountAddress: addr,
-		CreatedTime:       ctx.BlockHeader().Time,
-	}
+
+	tx.ID = transactionID
+	tx.Type = txType
+	tx.ReferenceID = referenceID
+	tx.Amount = amt
+	tx.AppAccountAddress = addr
+	tx.CreatedTime = ctx.BlockHeader().Time
+
 	k.setTransaction(ctx, tx)
 	k.setTransactionID(ctx, transactionID+1)
 	k.setUserTransaction(ctx, addr, tx.CreatedTime, tx.ID)

--- a/x/staking/alias.go
+++ b/x/staking/alias.go
@@ -17,3 +17,7 @@ const (
 type (
 	TransactionType = exported.TransactionType
 )
+
+var (
+	WithCommunityID = exported.WithCommunityID
+)

--- a/x/staking/expected_keepers.go
+++ b/x/staking/expected_keepers.go
@@ -1,9 +1,9 @@
 package staking
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankexported "github.com/TruStory/truchain/x/bank/exported"
 	"github.com/TruStory/truchain/x/claim"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type AccountKeeper interface {
@@ -18,9 +18,9 @@ type ClaimKeeper interface {
 // BankKeeper is the expected bank keeper interface for this module
 type BankKeeper interface {
 	AddCoin(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin,
-		referenceID uint64, txType bankexported.TransactionType) (sdk.Coins, sdk.Error)
+		referenceID uint64, txType bankexported.TransactionType, setters ...bankexported.TransactionSetter) (sdk.Coins, sdk.Error)
 	GetCoins(ctx sdk.Context, address sdk.AccAddress) sdk.Coins
 	SubtractCoin(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coin,
-		referenceID uint64, txType TransactionType) (sdk.Coins, sdk.Error)
+		referenceID uint64, txType TransactionType, setters ...bankexported.TransactionSetter) (sdk.Coins, sdk.Error)
 	TransactionsByAddress(ctx sdk.Context, address sdk.AccAddress, filterSetters ...bankexported.Filter) []bankexported.Transaction
 }

--- a/x/staking/keeper.go
+++ b/x/staking/keeper.go
@@ -196,6 +196,7 @@ func (k Keeper) SubmitArgument(ctx sdk.Context, body, summary string,
 		ID:           argumentID,
 		Creator:      creator,
 		ClaimID:      claimID,
+		CommunityID:  claim.CommunityID,
 		Summary:      summary,
 		Body:         body,
 		StakeType:    stakeType,
@@ -274,13 +275,15 @@ func (k Keeper) newStake(ctx sdk.Context, amount sdk.Coin, creator sdk.AccAddres
 	if err != nil {
 		return Stake{}, err
 	}
-	_, err = k.bankKeeper.SubtractCoin(ctx, creator, amount, argumentID, stakeType.BankTransactionType())
+	_, err = k.bankKeeper.SubtractCoin(ctx, creator, amount,
+		argumentID, stakeType.BankTransactionType(), WithCommunityID(communityID))
 	if err != nil {
 		return Stake{}, err
 	}
 	stake := Stake{
 		ID:          stakeID,
 		ArgumentID:  argumentID,
+		CommunityID: communityID,
 		CreatedTime: ctx.BlockHeader().Time,
 		EndTime:     ctx.BlockHeader().Time.Add(period),
 		Creator:     creator,

--- a/x/staking/keeper_test.go
+++ b/x/staking/keeper_test.go
@@ -60,6 +60,7 @@ func TestKeeper_SubmitArgument(t *testing.T) {
 		ID:           1,
 		Creator:      addr,
 		ClaimID:      1,
+		CommunityID:  "testunit",
 		Summary:      "summary",
 		Body:         "body",
 		StakeType:    StakeBacking,
@@ -77,6 +78,7 @@ func TestKeeper_SubmitArgument(t *testing.T) {
 	expectedStake := Stake{
 		ID:          1,
 		ArgumentID:  1,
+		CommunityID: "testunit",
 		Type:        StakeBacking,
 		Amount:      sdk.NewInt64Coin(app.StakeDenom, app.Shanev*50),
 		Creator:     addr,
@@ -90,6 +92,7 @@ func TestKeeper_SubmitArgument(t *testing.T) {
 		ID:           2,
 		Creator:      addr2,
 		ClaimID:      1,
+		CommunityID:  "testunit",
 		Summary:      "summary2",
 		Body:         "body2",
 		StakeType:    StakeChallenge,
@@ -101,6 +104,7 @@ func TestKeeper_SubmitArgument(t *testing.T) {
 	expectedStake2 := Stake{
 		ID:          2,
 		ArgumentID:  2,
+		CommunityID: "testunit",
 		Type:        StakeChallenge,
 		Amount:      sdk.NewInt64Coin(app.StakeDenom, app.Shanev*50),
 		Creator:     addr2,
@@ -213,6 +217,7 @@ func TestKeeper_SubmitUpvote(t *testing.T) {
 	expectedStake := Stake{
 		ID:          1,
 		ArgumentID:  1,
+		CommunityID: "testunit",
 		Type:        StakeBacking,
 		Amount:      sdk.NewInt64Coin(app.StakeDenom, app.Shanev*50),
 		Creator:     addr,
@@ -227,6 +232,7 @@ func TestKeeper_SubmitUpvote(t *testing.T) {
 	expectedStake2 := Stake{
 		ID:          2,
 		ArgumentID:  1,
+		CommunityID: "testunit",
 		Type:        StakeUpvote,
 		Amount:      sdk.NewInt64Coin(app.StakeDenom, app.Shanev*10),
 		Creator:     addr2,

--- a/x/staking/types.go
+++ b/x/staking/types.go
@@ -74,6 +74,7 @@ func (t StakeType) oneOf(types []StakeType) bool {
 type Stake struct {
 	ID          uint64         `json:"id"`
 	ArgumentID  uint64         `json:"argument_id"`
+	CommunityID string         `json:"community_id"`
 	Type        StakeType      `json:"type"`
 	Amount      sdk.Coin       `json:"amount"`
 	Creator     sdk.AccAddress `json:"creator"`
@@ -87,6 +88,7 @@ type Argument struct {
 	ID             uint64         `json:"id"`
 	Creator        sdk.AccAddress `json:"creator"`
 	ClaimID        uint64         `json:"claim_id"`
+	CommunityID    string         `json:"community_id"`
 	Summary        string         `json:"summary"`
 	Body           string         `json:"body"`
 	StakeType      StakeType      `json:"stake_type"`


### PR DESCRIPTION
This only requires a change in expected_keeper if a module depend on bank, but existing calls to the methods won't break unless you want to send a community id (more flexible for future  additions)