### PR TITLE
Add transactions allowed for earning

### DIFF
--- a/x/bank/exported/exported.go
+++ b/x/bank/exported/exported.go
@@ -83,6 +83,13 @@ var AllowedTransactionsForEarning = []TransactionType{
 	TransactionCuratorReward,
 }
 
+var AllowedTransactionsForEarning = []TransactionType{
+	TransactionInterestArgumentCreation,
+	TransactionInterestUpvoteReceived,
+	TransactionInterestUpvoteGiven,
+	TransactionCuratorReward,
+}
+
 var AllowedTransactionsForDeduction = []TransactionType{
 	TransactionBacking,
 	TransactionChallenge,


### PR DESCRIPTION
- Wallet keeps track of earned totals. This will help to differentiate net earnings from other types of transactions