### PR TITLE
Do not reset UpvotedCount if argument is edited

### DIFF
--- a/x/staking/keeper.go
+++ b/x/staking/keeper.go
@@ -623,6 +623,7 @@ func (k Keeper) EditArgument(ctx sdk.Context, body, summary string,
 		UpdatedTime:  argument.UpdatedTime,
 		UpvotedStake: argument.UpvotedStake,
 		TotalStake:   argument.TotalStake,
+		UpvotedCount: argument.UpvotedCount,
 		EditedTime:   ctx.BlockHeader().Time,
 		Edited:       true,
 	}


### PR DESCRIPTION
Editing an argument by an admin reset the UpvoteCount to 0. The UpvoteCount on some arguments no longer matches the number of participants. Will need to fix with migration in the future but need to fix this bug ASAP

<img width="340" alt="Screen Shot 2019-09-16 at 2 17 23 PM" src="https://user-images.githubusercontent.com/43760810/64994246-f4777000-d88c-11e9-99d6-e7e57b2f787c.png">

- [ ] Linked to Github issues that this PR fixes (if any)
- [ ] Wrote tests
- [ ] Updated README.md if needed
- [ ] Updated docs/spec if needed
- [x] Tested running truchain, truapi, and truapp locally (https://gist.github.com/shanev/3897a80072ac4147677fa596ada497fb)
