### PR TITLE
Fix fetching auth account for params CLI

### DIFF
--- a/cmd/truchaincli/params.go
+++ b/cmd/truchaincli/params.go
@@ -5,10 +5,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/cosmos/cosmos-sdk/x/auth"
-
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/TruStory/truchain/x/account"
 	"github.com/TruStory/truchain/x/bank"
 	"github.com/TruStory/truchain/x/claim"
@@ -20,7 +16,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 )
 
@@ -83,8 +80,8 @@ func AccountParamsCmd(cdc *codec.Codec) *cobra.Command {
 				panic(err)
 			}
 
+			cliCtx := context.NewCLIContextWithFrom(args[0]).WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			msg := account.NewMsgUpdateParams(updates, updatedFields, cliCtx.GetFromAddress())
 			fromName := cliCtx.GetFromName()
@@ -159,8 +156,8 @@ func BankParamsCmd(cdc *codec.Codec) *cobra.Command {
 				panic(err)
 			}
 
+			cliCtx := context.NewCLIContextWithFrom(args[0]).WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			msg := bank.NewMsgUpdateParams(updates, updatedFields, cliCtx.GetFromAddress())
 			fromName := cliCtx.GetFromName()
@@ -235,8 +232,8 @@ func ClaimParamsCmd(cdc *codec.Codec) *cobra.Command {
 				panic(err)
 			}
 
+			cliCtx := context.NewCLIContextWithFrom(args[0]).WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			msg := claim.NewMsgUpdateParams(updates, updatedFields, cliCtx.GetFromAddress())
 			fromName := cliCtx.GetFromName()
@@ -311,8 +308,8 @@ func CommunityParamsCmd(cdc *codec.Codec) *cobra.Command {
 				panic(err)
 			}
 
+			cliCtx := context.NewCLIContextWithFrom(args[0]).WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			msg := community.NewMsgUpdateParams(updates, updatedFields, cliCtx.GetFromAddress())
 			fromName := cliCtx.GetFromName()
@@ -387,8 +384,8 @@ func SlashingParamsCmd(cdc *codec.Codec) *cobra.Command {
 				panic(err)
 			}
 
+			cliCtx := context.NewCLIContextWithFrom(args[0]).WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			msg := slashing.NewMsgUpdateParams(updates, updatedFields, cliCtx.GetFromAddress())
 			fromName := cliCtx.GetFromName()
@@ -463,8 +460,8 @@ func StakingParamsCmd(cdc *codec.Codec) *cobra.Command {
 				panic(err)
 			}
 
+			cliCtx := context.NewCLIContextWithFrom(args[0]).WithCodec(cdc)
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			msg := staking.NewMsgUpdateParams(updates, updatedFields, cliCtx.GetFromAddress())
 			fromName := cliCtx.GetFromName()


### PR DESCRIPTION
- [ ] Linked to Github issues that this PR fixes (if any)
- [ ] Wrote tests
- [ ] Updated README.md if needed
- [ ] Updated docs/spec if needed
- [x] Tested running truchain, truapi, and truapp locally (https://gist.github.com/shanev/3897a80072ac4147677fa596ada497fb)

Tested on devnet:
```
$ truchaincli params staking cosmos1tfpcnjzkthft3ynewqvn7mtdk7guf3knjdqg4d --upvote_stake 30000000000tru --chain-id devnet-n --home ~/.octopus                                                                                      [1:06:20]
Password to sign with 'reward_broker':
Response:
  Height: 351922
  TxHash: EF4C58DD8AC5A4C721F1E5F6DC420F805679D47E864B7F74BF76298308C457A3
  Data: 74727565
  Raw Log: [{"msg_index":0,"success":true,"log":""}]
  Logs: [{"msg_index":0,"success":true,"log":""}]
  GasUsed: 110280
  Events:
        - message
            - action: update_params
```